### PR TITLE
🐛 Fix the use of empty styledTextSegments array

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -72,21 +72,24 @@ function traverse(node): NodeData {
 
   if (node.type == "TEXT") {
     const styledTextSegments = node.getStyledTextSegments(["fontName", "fontSize", "fontWeight", "lineHeight", "letterSpacing", "textCase", "textDecoration", "fills"]);
-    let font = {
-      fontName: styledTextSegments[0].fontName,
-      fontSize: styledTextSegments[0].fontSize.toString(),
-      fontWeight: styledTextSegments[0].fontWeight.toString(),
-      characters: node.characters,
-      lineHeight: styledTextSegments[0].lineHeight,
-      letterSpacing: styledTextSegments[0].letterSpacing,
-      fills: styledTextSegments[0].fills,
-      textCase: styledTextSegments[0].textCase,
-      textDecoration: styledTextSegments[0].textDecoration,
-      textAlignHorizontal: node.textAlignHorizontal,
-      textAlignVertical: node.textAlignVertical,
-      children: styledTextSegments
-    };
-    result = {...result, ...font};
+
+    if (styledTextSegments[0]) {
+      let font = {
+        fontName: styledTextSegments[0].fontName,
+        fontSize: styledTextSegments[0].fontSize.toString(),
+        fontWeight: styledTextSegments[0].fontWeight.toString(),
+        characters: node.characters,
+        lineHeight: styledTextSegments[0].lineHeight,
+        letterSpacing: styledTextSegments[0].letterSpacing,
+        fills: styledTextSegments[0].fills,
+        textCase: styledTextSegments[0].textCase,
+        textDecoration: styledTextSegments[0].textDecoration,
+        textAlignHorizontal: node.textAlignHorizontal,
+        textAlignVertical: node.textAlignVertical,
+        children: styledTextSegments
+      };
+      result = {...result, ...font};
+    }
   }
 
   return result;


### PR DESCRIPTION
When a TextNode contains empty characters field, getStyledTextSegments returns empty array. This causes a TypeError, described in issue #29 , when we try to access the properties of the first element of this array.

This change adds a check if the first element of the styledTextSegments exists before using its properties.