### PR TITLE
Frames & Sections

### DIFF
--- a/plugin-src/transformers/transformFrameNode.ts
+++ b/plugin-src/transformers/transformFrameNode.ts
@@ -8,8 +8,12 @@ import { translateFills } from '@plugin/translators';
 
 import { FrameShape } from '@ui/lib/types/frame/frameShape';
 
+const isSectionNode = (node: FrameNode | SectionNode): node is SectionNode => {
+  return node.type === 'SECTION';
+};
+
 export const transformFrameNode = async (
-  node: FrameNode,
+  node: FrameNode | SectionNode,
   baseX: number,
   baseY: number
 ): Promise<FrameShape> => {
@@ -17,8 +21,11 @@ export const transformFrameNode = async (
     type: 'frame',
     name: node.name,
     fills: translateFills(node.fills, node.width, node.height),
-    ...transformStrokes(node),
-    ...(await transformChildren(node, baseX, baseY)),
+    // Figma API does not expose strokes for sections,
+    // they plan to add it in the future. Refactor this when available.
+    // @see: https://forum.figma.com/t/why-are-strokes-not-available-on-section-nodes/41658
+    ...(isSectionNode(node) ? [] : transformStrokes(node)),
+    ...(await transformChildren(node, baseX + node.x, baseY + node.y)),
     ...transformDimensionAndPosition(node, baseX, baseY),
     ...transformSceneNode(node)
   };

--- a/plugin-src/transformers/transformFrameNode.ts
+++ b/plugin-src/transformers/transformFrameNode.ts
@@ -1,4 +1,5 @@
 import {
+  transformBlend,
   transformDimensionAndPosition,
   transformSceneNode,
   transformStrokes
@@ -27,6 +28,10 @@ export const transformFrameNode = async (
     ...(isSectionNode(node) ? [] : transformStrokes(node)),
     ...(await transformChildren(node, baseX + node.x, baseY + node.y)),
     ...transformDimensionAndPosition(node, baseX, baseY),
+    // Figma API does not expose blend modes for sections,
+    // they plan to add it in the future. Refactor this when available.
+    // @see: https://forum.figma.com/t/add-a-blendmode-property-for-sectionnode/58560
+    ...(isSectionNode(node) ? [] : transformBlend(node)),
     ...transformSceneNode(node)
   };
 };

--- a/plugin-src/transformers/transformSceneNode.ts
+++ b/plugin-src/transformers/transformSceneNode.ts
@@ -35,6 +35,7 @@ export const transformSceneNode = async (
       return transformRectangleNode(node, baseX, baseY);
     case 'ELLIPSE':
       return transformEllipseNode(node, baseX, baseY);
+    case 'SECTION':
     case 'FRAME':
       return await transformFrameNode(node, baseX, baseY);
     case 'GROUP':


### PR DESCRIPTION
https://github.com/orgs/Runroom/projects/1/views/1?pane=issue&itemId=59550635

👤 **User story**

_As a Figma/Penpot user, I want to be able to edit and view frames & sections created in Figma also in Penpot when importing a Figma file to Penpot, so that I can seamlessly continue my design work._

✅ **Acceptance criteria** 

- [x] Replicate size, position, order of frames created in Figma in Penpot.
- [x] Frames created in Figma are displayed as editable frames in Penpot.
- [x] Sections are translated to frames in Penpot.
- [x] Support for opacity & blend modes.
- [x] Test file in Figma to confirm the correct export/import of the file to Penpot.
