### PR TITLE
Strokes

### DIFF
--- a/plugin-src/transformers/partials/transformStrokes.ts
+++ b/plugin-src/transformers/partials/transformStrokes.ts
@@ -2,23 +2,56 @@ import { translateStrokes } from '@plugin/translators';
 
 import { ShapeAttributes } from '@ui/lib/types/shape/shapeAttributes';
 
+export type NodeStrokes = {
+  strokes: readonly Paint[];
+  strokeWeight: number | typeof figma.mixed;
+  strokeAlign: 'CENTER' | 'INSIDE' | 'OUTSIDE';
+  dashPattern: readonly number[];
+};
+
 const isVectorLike = (node: GeometryMixin | VectorLikeMixin): node is VectorLikeMixin => {
   return 'vectorNetwork' in node;
+};
+
+const isIndividualStrokes = (
+  node: DefaultShapeMixin | IndividualStrokesMixin
+): node is IndividualStrokesMixin => {
+  return 'strokeTopWeight' in node;
 };
 
 const hasFillGeometry = (node: GeometryMixin | (GeometryMixin & VectorLikeMixin)): boolean => {
   return node.fillGeometry.length > 0;
 };
 
+const getNodeStrokes = (
+  node: DefaultShapeMixin | (DefaultShapeMixin & IndividualStrokesMixin)
+): NodeStrokes => {
+  return {
+    strokes: node.strokes,
+    strokeWeight: node.strokeWeight,
+    strokeAlign: node.strokeAlign,
+    dashPattern: node.dashPattern
+  };
+};
+
+const getIndividualStrokes = (node: IndividualStrokesMixin): IndividualStrokesMixin => {
+  return {
+    strokeTopWeight: node.strokeTopWeight,
+    strokeRightWeight: node.strokeRightWeight,
+    strokeBottomWeight: node.strokeBottomWeight,
+    strokeLeftWeight: node.strokeLeftWeight
+  };
+};
+
 export const transformStrokes = (
-  node: GeometryMixin | (GeometryMixin & VectorLikeMixin)
+  node: DefaultShapeMixin | (DefaultShapeMixin & IndividualStrokesMixin)
 ): Partial<ShapeAttributes> => {
   return {
     strokes: translateStrokes(
-      node.strokes,
-      node.strokeWeight,
+      getNodeStrokes(node),
       hasFillGeometry(node),
-      isVectorLike(node) ? node.vectorNetwork : undefined
+      isVectorLike(node) ? node.vectorNetwork : undefined,
+      isIndividualStrokes(node) ? getIndividualStrokes(node) : undefined
     )
   };
 };

--- a/plugin-src/transformers/partials/transformStrokes.ts
+++ b/plugin-src/transformers/partials/transformStrokes.ts
@@ -2,13 +2,6 @@ import { translateStrokes } from '@plugin/translators';
 
 import { ShapeAttributes } from '@ui/lib/types/shape/shapeAttributes';
 
-export type NodeStrokes = {
-  strokes: readonly Paint[];
-  strokeWeight: number | typeof figma.mixed;
-  strokeAlign: 'CENTER' | 'INSIDE' | 'OUTSIDE';
-  dashPattern: readonly number[];
-};
-
 const isVectorLike = (node: GeometryMixin | VectorLikeMixin): node is VectorLikeMixin => {
   return 'vectorNetwork' in node;
 };
@@ -23,33 +16,15 @@ const hasFillGeometry = (node: GeometryMixin): boolean => {
   return node.fillGeometry.length > 0;
 };
 
-const getNodeStrokes = (node: GeometryMixin): NodeStrokes => {
-  return {
-    strokes: node.strokes,
-    strokeWeight: node.strokeWeight,
-    strokeAlign: node.strokeAlign,
-    dashPattern: node.dashPattern
-  };
-};
-
-const getIndividualStrokes = (node: IndividualStrokesMixin): IndividualStrokesMixin => {
-  return {
-    strokeTopWeight: node.strokeTopWeight,
-    strokeRightWeight: node.strokeRightWeight,
-    strokeBottomWeight: node.strokeBottomWeight,
-    strokeLeftWeight: node.strokeLeftWeight
-  };
-};
-
 export const transformStrokes = (
   node: GeometryMixin | (GeometryMixin & IndividualStrokesMixin)
 ): Partial<ShapeAttributes> => {
   return {
     strokes: translateStrokes(
-      getNodeStrokes(node),
+      node,
       hasFillGeometry(node),
       isVectorLike(node) ? node.vectorNetwork : undefined,
-      isIndividualStrokes(node) ? getIndividualStrokes(node) : undefined
+      isIndividualStrokes(node) ? node : undefined
     )
   };
 };

--- a/plugin-src/transformers/partials/transformStrokes.ts
+++ b/plugin-src/transformers/partials/transformStrokes.ts
@@ -14,18 +14,16 @@ const isVectorLike = (node: GeometryMixin | VectorLikeMixin): node is VectorLike
 };
 
 const isIndividualStrokes = (
-  node: DefaultShapeMixin | IndividualStrokesMixin
+  node: GeometryMixin | IndividualStrokesMixin
 ): node is IndividualStrokesMixin => {
   return 'strokeTopWeight' in node;
 };
 
-const hasFillGeometry = (node: GeometryMixin | (GeometryMixin & VectorLikeMixin)): boolean => {
+const hasFillGeometry = (node: GeometryMixin): boolean => {
   return node.fillGeometry.length > 0;
 };
 
-const getNodeStrokes = (
-  node: DefaultShapeMixin | (DefaultShapeMixin & IndividualStrokesMixin)
-): NodeStrokes => {
+const getNodeStrokes = (node: GeometryMixin): NodeStrokes => {
   return {
     strokes: node.strokes,
     strokeWeight: node.strokeWeight,
@@ -44,7 +42,7 @@ const getIndividualStrokes = (node: IndividualStrokesMixin): IndividualStrokesMi
 };
 
 export const transformStrokes = (
-  node: DefaultShapeMixin | (DefaultShapeMixin & IndividualStrokesMixin)
+  node: GeometryMixin | (GeometryMixin & IndividualStrokesMixin)
 ): Partial<ShapeAttributes> => {
   return {
     strokes: translateStrokes(

--- a/plugin-src/translators/translateStrokes.ts
+++ b/plugin-src/translators/translateStrokes.ts
@@ -1,19 +1,22 @@
+import { NodeStrokes } from '@plugin/transformers/partials';
 import { translateFill } from '@plugin/translators/translateFills';
 
-import { Stroke, StrokeCaps } from '@ui/lib/types/utils/stroke';
+import { Stroke, StrokeAlignment, StrokeCaps } from '@ui/lib/types/utils/stroke';
 
 export const translateStrokes = (
-  paints: readonly Paint[],
-  strokeWeight: number | typeof figma.mixed,
+  nodeStrokes: NodeStrokes,
   hasFillGeometry?: boolean,
-  vectorNetwork?: VectorNetwork
+  vectorNetwork?: VectorNetwork,
+  individualStrokes?: IndividualStrokesMixin
 ): Stroke[] => {
-  return paints.map((paint, index) => {
+  return nodeStrokes.strokes.map((paint, index) => {
     const fill = translateFill(paint, 0, 0);
     const stroke: Stroke = {
       strokeColor: fill?.fillColor,
       strokeOpacity: fill?.fillOpacity,
-      strokeWidth: strokeWeight === figma.mixed ? 1 : strokeWeight
+      strokeWidth: translateStrokeWeight(nodeStrokes.strokeWeight, individualStrokes),
+      strokeAlignment: translateStrokeAlignment(nodeStrokes.strokeAlign),
+      strokeStyle: nodeStrokes.dashPattern.length ? 'dashed' : 'solid'
     };
 
     if (!hasFillGeometry && index === 0 && vectorNetwork && vectorNetwork.vertices.length) {
@@ -25,6 +28,39 @@ export const translateStrokes = (
 
     return stroke;
   });
+};
+
+const translateStrokeWeight = (
+  strokeWeight: number | typeof figma.mixed,
+  individualStrokes?: IndividualStrokesMixin
+): number => {
+  if (strokeWeight !== figma.mixed) {
+    return strokeWeight;
+  }
+
+  if (!individualStrokes) {
+    return 1;
+  }
+
+  return Math.max(
+    individualStrokes.strokeTopWeight,
+    individualStrokes.strokeRightWeight,
+    individualStrokes.strokeBottomWeight,
+    individualStrokes.strokeLeftWeight
+  );
+};
+
+const translateStrokeAlignment = (
+  strokeAlign: 'CENTER' | 'INSIDE' | 'OUTSIDE'
+): StrokeAlignment => {
+  switch (strokeAlign) {
+    case 'CENTER':
+      return 'center';
+    case 'INSIDE':
+      return 'inner';
+    case 'OUTSIDE':
+      return 'outer';
+  }
 };
 
 const translateStrokeCap = (vertex: VectorVertex): StrokeCaps | undefined => {

--- a/plugin-src/translators/translateStrokes.ts
+++ b/plugin-src/translators/translateStrokes.ts
@@ -1,10 +1,9 @@
-import { NodeStrokes } from '@plugin/transformers/partials';
 import { translateFill } from '@plugin/translators/translateFills';
 
 import { Stroke, StrokeAlignment, StrokeCaps } from '@ui/lib/types/utils/stroke';
 
 export const translateStrokes = (
-  nodeStrokes: NodeStrokes,
+  nodeStrokes: MinimalStrokesMixin,
   hasFillGeometry?: boolean,
   vectorNetwork?: VectorNetwork,
   individualStrokes?: IndividualStrokesMixin


### PR DESCRIPTION
👤 **User story**

_As a Figma/Penpot user, I want to be able to edit and view strokes created in Figma also in Penpot when importing a Figma file to Penpot, so that I can seamlessly continue my design work._


✅ **Acceptance criteria**

- [x] Consider solution for local variables in Figma (included in the Research section below).
- [x] Strokes created in Figma are displayed as editable strokes in Penpot.
- [x] Support for Solid Stroke (Figma & Penpot).
- [x] Support for Dashed Stroke (Figma & Penpot).
- [x] Advanced Stroke Settings in Figma: Translated as Dashed in Penpot.
- [x] Replicate Position: Center, Inside, Outside.
- [x] Replicate Weight (px).
- [x] Support for color (will be worked on in other US "HEX & RGB").
- [x] Support for strokes applied to: Rectangles, circles, vector paths, vector networks and frames. (boolean groups will be worked in other US)
- [x] Stroke per side in Figma is applied to all sides in Penpot.
- [x] Support for multiple layers of strokes.
- [x] Support for position of multiple strokes in Figma (translation to Penpot).
- [x] Support for opacity & blend modes.
- [x] Test file in Figma to confirm the correct export/import of the file to Penpot.

---

📄 **Documentation**

Guides:
[Figma](https://help.figma.com/hc/en-us/articles/360049283914-Apply-and-adjust-stroke-properties)
[Penpot](https://help.penpot.app/user-guide/styling/#strokes)

Supported properties in both Penpot and Figma:
- Position: Center, Inside, Outside
- Weight (px)
- Color and opacity
- Style: Solid & dashed 
Penpot (Solid, Dotted, Dashed, Mixed)
![Image](https://github.com/orgs/Runroom/projects/1/assets/165997885/147111f0-710a-4520-9d11-58dfaaf9ce55)
Figma (Solid, Dashed & Custom/Advanced stroke)
![Image](https://github.com/orgs/Runroom/projects/1/assets/165997885/4b363b73-14f0-4ae4-b2b7-d71470c8ff4c)

ℹ Figma also supports:

- Strokes per side 
- Saving stroke settings as a Local style or Local variable (beta)
- Advaced/custom stroke settings (applies to all vector paths, including paths or vector networks with Pen or Pencil)

---

**🔎 Research**

- What happens when a stroke is related to a local variable or a design system library?
⚠️ [Local variables are in beta](https://help.figma.com/hc/en-us/articles/14506821864087-Overview-of-variables-collections-and-modes)


