### PR TITLE
temporary hide url with further instructions

### DIFF
--- a/plugin-src/pluginSizes.ts
+++ b/plugin-src/pluginSizes.ts
@@ -2,7 +2,7 @@ export const LOADING_HEIGHT = 130;
 export const NORMAL_HEIGHT = LOADING_HEIGHT + 5;
 export const BASE_WIDTH = 290;
 
-export const MISSING_FONTS_TEXT_HEIGHT = 195;
+export const MISSING_FONTS_TEXT_HEIGHT = 195 - 15;
 export const MISSING_SINGLE_FONT_HEIGHT = 65;
 
 export const NEEDS_RELOAD_TEXT_HEIGHT = 90;

--- a/ui-src/components/MissingFontsSection.tsx
+++ b/ui-src/components/MissingFontsSection.tsx
@@ -1,4 +1,5 @@
-import { Banner, IconInfo32, Link, Textbox } from '@create-figma-plugin/ui';
+// import { Banner, IconInfo32, Link, Textbox } from '@create-figma-plugin/ui';
+import { Banner, IconInfo32, Textbox } from '@create-figma-plugin/ui';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { Stack } from './Stack';
@@ -20,10 +21,10 @@ export const MissingFontsSection = ({ fonts }: MissingFontsSectionProps) => {
         <Stack as="ol" space="xsmall" style={{ paddingLeft: '1rem' }}>
           <li>
             Upload your local fonts in Penpot.
-            <br />
+            {/* <br />
             <Link href="https://www.google.com" target="_blank" rel="noreferrer">
               Learn how to do it.
-            </Link>
+            </Link> */}
           </li>
           <li>Copy and paste the font IDs from Penpot below.</li>
         </Stack>


### PR DESCRIPTION
When the blogpost/instructions to copy the fonts id are published this PR should be reverted.