### PR TITLE
Disable sentry while developing the plugin

### DIFF
--- a/.changeset/moody-onions-worry.md
+++ b/.changeset/moody-onions-worry.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Disable Sentry in development mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "penpot-exporter",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "penpot-exporter",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "MPL2.0",
       "dependencies": {
         "@create-figma-plugin/ui": "^4.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,37 +6,40 @@ import { viteSingleFile } from 'vite-plugin-singlefile';
 import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-export default defineConfig({
-  root: './ui-src',
-  plugins: [
-    svgr(),
-    react(),
-    viteSingleFile({ removeViteModuleLoader: true }),
-    tsconfigPaths(),
-    sentryVitePlugin({
-      org: 'runroom-sl',
-      project: 'penpot-exporter'
-    })
-  ],
-  resolve: {
-    alias: {
-      'react': 'preact/compat',
-      'react-dom': 'preact/compat',
-      '!../css/base.css': '../css/base.css'
-    }
-  },
-  build: {
-    emptyOutDir: false,
-    target: 'esnext',
-    reportCompressedSize: false,
-    outDir: '../dist',
-
-    rollupOptions: {
-      external: ['!../css/base.css']
+export default ({ mode }) => {
+  return defineConfig({
+    root: './ui-src',
+    plugins: [
+      svgr(),
+      react(),
+      viteSingleFile({ removeViteModuleLoader: true }),
+      tsconfigPaths(),
+      sentryVitePlugin({
+        org: 'runroom-sl',
+        project: 'penpot-exporter',
+        disable: mode === 'development'
+      })
+    ],
+    resolve: {
+      alias: {
+        'react': 'preact/compat',
+        'react-dom': 'preact/compat',
+        '!../css/base.css': '../css/base.css'
+      }
     },
-    sourcemap: true
-  },
-  define: {
-    APP_VERSION: JSON.stringify(process.env.npm_package_version)
-  }
-});
+    build: {
+      emptyOutDir: false,
+      target: 'esnext',
+      reportCompressedSize: false,
+      outDir: '../dist',
+
+      rollupOptions: {
+        external: ['!../css/base.css']
+      },
+      sourcemap: true
+    },
+    define: {
+      APP_VERSION: JSON.stringify(process.env.npm_package_version)
+    }
+  });
+};


### PR DESCRIPTION
This pull request updates the `vite.config.ts` configuration to improve environment-specific behavior and plugin management. The main change is making the Vite config export a function that receives the build mode, allowing conditional configuration of plugins.

Configuration improvements:

* Refactored the default export in `vite.config.ts` to be a function that receives the `mode` parameter, enabling dynamic configuration based on the environment.
* Updated the Sentry plugin configuration to disable Sentry when running in development mode by checking the `mode` parameter.

Other changes:

* Added a closing bracket to properly terminate the new function export in `vite.config.ts`.