### PR TITLE
Improve svg rotations

### DIFF
--- a/.changeset/puny-dryers-peel.md
+++ b/.changeset/puny-dryers-peel.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Fix some cases where an SVG might not be correctly rotated

--- a/plugin-src/transformers/partials/transformRotationAndPosition.ts
+++ b/plugin-src/transformers/partials/transformRotationAndPosition.ts
@@ -19,10 +19,7 @@ export const transformRotationAndPosition = (
   const y = node.absoluteTransform[1][2];
   const rotation = getRotation(node.absoluteTransform);
 
-  if (
-    !node.absoluteBoundingBox ||
-    !isTransformed(node.absoluteTransform, node.absoluteBoundingBox)
-  ) {
+  if (!node.absoluteBoundingBox || !isTransformed(node.absoluteTransform)) {
     return {
       x,
       y,

--- a/plugin-src/translators/vectors/translateCommands.ts
+++ b/plugin-src/translators/vectors/translateCommands.ts
@@ -5,7 +5,7 @@ import { translateRotatedCommands } from '@plugin/translators/vectors/translateR
 import { isTransformed } from '@plugin/utils';
 
 export const translateCommands = (node: LayoutMixin, commands: Command[]): string => {
-  if (node.absoluteBoundingBox && isTransformed(node.absoluteTransform, node.absoluteBoundingBox)) {
+  if (node.absoluteBoundingBox && isTransformed(node.absoluteTransform)) {
     return translateRotatedCommands(commands, node.absoluteTransform, node.absoluteBoundingBox);
   }
 

--- a/plugin-src/utils/applyRotation.ts
+++ b/plugin-src/utils/applyRotation.ts
@@ -64,8 +64,8 @@ export const applyInverseRotation = (
 export const getRotation = (transform: Transform): number =>
   Math.acos(transform[0][0]) * (180 / Math.PI);
 
-export const isTransformed = (transform: Transform, boundingBox: Rect | null): boolean => {
-  return boundingBox !== null && !isIdentityMatrix(transform);
+export const isTransformed = (transform: Transform): boolean => {
+  return !isIdentityMatrix(transform);
 };
 
 const inverseMatrix = (matrix: Transform): Transform => [

--- a/plugin-src/utils/applyRotation.ts
+++ b/plugin-src/utils/applyRotation.ts
@@ -65,11 +65,7 @@ export const getRotation = (transform: Transform): number =>
   Math.acos(transform[0][0]) * (180 / Math.PI);
 
 export const isTransformed = (transform: Transform, boundingBox: Rect | null): boolean => {
-  if (!boundingBox) {
-    return false;
-  }
-
-  return transform[0][2] !== boundingBox.x || transform[1][2] !== boundingBox.y;
+  return boundingBox !== null && !isIdentityMatrix(transform);
 };
 
 const inverseMatrix = (matrix: Transform): Transform => [
@@ -81,6 +77,15 @@ const applyMatrix = (matrix: Transform, point: Point): Point => ({
   x: point.x * matrix[0][0] + point.y * matrix[0][1],
   y: point.x * matrix[1][0] + point.y * matrix[1][1]
 });
+
+const isIdentityMatrix = (matrix: Transform): boolean => {
+  return (
+    cleanNumber(matrix[0][0]) === 1 &&
+    cleanNumber(matrix[0][1]) === 0 &&
+    cleanNumber(matrix[1][0]) === 0 &&
+    cleanNumber(matrix[1][1]) === 1
+  );
+};
 
 const calculateCenter = (boundingBox: Rect): Point => ({
   x: boundingBox.x + boundingBox.width / 2,
@@ -97,3 +102,7 @@ const isVerticalLineTo = (command: Command): command is VerticalLineToCommand =>
 
 const isClosePath = (command: Command): command is ClosePathCommand =>
   command.command === 'closepath';
+
+const cleanNumber = (value: number, epsilon = 1e-6, decimals = 6): number => {
+  return Math.abs(value) < epsilon ? 0 : +value.toFixed(decimals);
+};


### PR DESCRIPTION
This pull request addresses issues with SVG rotation handling in the `penpot-exporter` plugin, ensuring that SVGs are correctly rotated in more cases. The main improvements involve refining how transformations are detected and processed, particularly by introducing more robust checks for identity matrices and cleaning up floating-point inaccuracies.

**SVG Transformation Handling Improvements:**

* Added a new `isIdentityMatrix` function in `plugin-src/utils/applyRotation.ts` to accurately detect when a transformation matrix represents no rotation or translation.
* Updated the `isTransformed` function to use the new `isIdentityMatrix` logic, improving detection of transformed SVG elements.

**Floating-point Precision Enhancements:**

* Introduced a `cleanNumber` utility in `plugin-src/utils/applyRotation.ts` to normalize small floating-point errors, ensuring matrix comparisons are reliable.

**General Plugin Patch:**

* Released a patch for `penpot-exporter` to fix cases where SVGs might not be correctly rotated. (.changeset/puny-dryers-peel.md)