### PR TITLE
Fix layout paddings, refactor on shapes without auto layout

### DIFF
--- a/.changeset/neat-coins-flow.md
+++ b/.changeset/neat-coins-flow.md
@@ -1,0 +1,6 @@
+---
+'penpot-exporter': patch
+---
+
+Fix scenario where paddings are the same as width/height and the inner element is moved from its
+original position

--- a/plugin-src/transformers/partials/transformLayout.ts
+++ b/plugin-src/transformers/partials/transformLayout.ts
@@ -19,17 +19,34 @@ import {
 import type { LayoutAttributes, LayoutChildAttributes } from '@ui/lib/types/shapes/layout';
 
 export const transformAutoLayout = (node: BaseFrameMixin): LayoutAttributes => {
-  return {
-    layout: translateLayoutMode(node.layoutMode),
-    layoutFlexDir: translateLayoutFlexDir(node.layoutMode),
+  const layout = translateLayoutMode(node.layoutMode);
+
+  if (layout === undefined) {
+    return {};
+  }
+
+  const commonAttributes: LayoutAttributes = {
+    layout,
     layoutGap: translateLayoutGap(node),
-    layoutWrapType: translateLayoutWrapType(node),
+    layoutGapType: 'multiple',
     layoutPadding: translateLayoutPadding(node),
     layoutPaddingType: translateLayoutPaddingType(node),
     layoutJustifyContent: translateLayoutJustifyContent(node),
     layoutJustifyItems: translateLayoutJustifyItems(node),
     layoutAlignContent: translateLayoutAlignContent(node),
-    layoutAlignItems: translateLayoutAlignItems(node),
+    layoutAlignItems: translateLayoutAlignItems(node)
+  };
+
+  if (layout === 'flex') {
+    return {
+      ...commonAttributes,
+      layoutFlexDir: translateLayoutFlexDir(node.layoutMode),
+      layoutWrapType: translateLayoutWrapType(node)
+    };
+  }
+
+  return {
+    ...commonAttributes,
     layoutGridDir: translateLayoutGridDir(node.layoutMode),
     layoutGridRows: translateGridTracks(node.gridRowSizes),
     layoutGridColumns: translateGridTracks(node.gridColumnSizes),

--- a/plugin-src/translators/translateLayout.ts
+++ b/plugin-src/translators/translateLayout.ts
@@ -108,12 +108,36 @@ export const translateLayoutWrapType = (node: BaseFrameMixin): LayoutWrapType | 
   }
 };
 
+/**
+ * If height is the same as the padding top and bottom, we need to reduce a bit the paddings to avoid a bug in Penpot
+ * Same happens for width and padding left and right.
+ *
+ * Just reducing 0.0001 is enough to avoid the bug.
+ *
+ * Figma allows the padding to be even greater than height or width, but we cannot fix all scenarios, because it
+ * means to modify the padding (that could also be linked to a token).
+ */
 export const translateLayoutPadding = (node: BaseFrameMixin): LayoutPadding => {
+  let p1 = node.paddingTop;
+  let p2 = node.paddingRight;
+  let p3 = node.paddingBottom;
+  let p4 = node.paddingLeft;
+
+  if (node.height > 0 && node.height === p1 + p3) {
+    p1 = p1 - 0.0001;
+    p3 = p3 - 0.0001;
+  }
+
+  if (node.width > 0 && node.width === p2 + p4) {
+    p2 = p2 - 0.0001;
+    p4 = p4 - 0.0001;
+  }
+
   return {
-    p1: node.paddingTop,
-    p2: node.paddingRight,
-    p3: node.paddingBottom,
-    p4: node.paddingLeft
+    p1,
+    p2,
+    p3,
+    p4
   };
 };
 


### PR DESCRIPTION
This pull request addresses a bug in the layout transformation logic where elements with paddings equal to their width or height would be incorrectly positioned after export. The main fix is to slightly reduce the padding values in these edge cases to avoid issues in Penpot, while also making related improvements to the layout transformation code.

**Bug fix for padding and layout export:**

* Added logic in `translateLayoutPadding` (`plugin-src/translators/translateLayout.ts`) to slightly reduce the padding values when the sum of paddings equals the width or height, preventing exported elements from shifting position in Penpot.
* Updated the changeset file `.changeset/neat-coins-flow.md` to document this fix.

**Improvements to layout transformation logic:**

* Refactored `transformAutoLayout` (`plugin-src/transformers/partials/transformLayout.ts`) to handle undefined layouts more gracefully, and to separate logic for flex and grid layouts for better maintainability.