### PR TITLE
Fix case where there are no variables in the Figma file

### DIFF
--- a/.changeset/nine-waves-boil.md
+++ b/.changeset/nine-waves-boil.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Fix case where there are no variables in the Figma file

--- a/plugin-src/processors/processTokens.ts
+++ b/plugin-src/processors/processTokens.ts
@@ -86,7 +86,7 @@ const getVariables = async (collection: VariableCollection): Promise<Variable[]>
   return variables;
 };
 
-export const processTokens = async (): Promise<Tokens> => {
+export const processTokens = async (): Promise<Tokens | undefined> => {
   const localCollections = await figma.variables.getLocalVariableCollectionsAsync();
 
   const sets: TokenSets = {};
@@ -110,6 +110,10 @@ export const processTokens = async (): Promise<Tokens> => {
         activeSets.push(setName);
       }
     }
+  }
+
+  if (tokenSetOrder.length === 0) {
+    return;
   }
 
   return {

--- a/ui-src/parser/parse.ts
+++ b/ui-src/parser/parse.ts
@@ -29,7 +29,10 @@ export const parse = async (document: PenpotDocument): Promise<PenpotContext> =>
   await buildFile(context, children);
   await buildComponentsLibrary(context);
 
-  context.addTokensLib(tokens);
+  if (tokens) {
+    context.addTokensLib(tokens);
+  }
+
   context.closeFile();
 
   flushMessageQueue();

--- a/ui-src/types/penpotDocument.ts
+++ b/ui-src/types/penpotDocument.ts
@@ -11,7 +11,7 @@ export type PenpotDocument = {
   images: Record<string, Uint8Array<ArrayBuffer>>;
   paintStyles: Record<string, FillStyle>;
   textStyles: Record<string, TypographyStyle>;
-  tokens: Tokens;
+  tokens?: Tokens;
   componentProperties: Record<string, ComponentProperty>;
   variantProperties: Record<string, string[]>;
   missingFonts: string[];


### PR DESCRIPTION
This pull request addresses an issue where the exporter failed when there were no variables in the Figma file. The changes ensure that the code can gracefully handle cases with no variables present, preventing errors and improving robustness.

**Handling empty variables in Figma files:**

* Updated `processTokens` to return `undefined` when there are no variable collections, avoiding the creation of empty token sets. (`plugin-src/processors/processTokens.ts`, [[1]](diffhunk://#diff-4bbe933315c2e89202f40af8233db5001054ff5899fb9d9679a571dc9ab524b3L89-R89) [[2]](diffhunk://#diff-4bbe933315c2e89202f40af8233db5001054ff5899fb9d9679a571dc9ab524b3R115-R118)
* Changed the `tokens` property in the `PenpotDocument` type to be optional, reflecting that tokens may not always be present. (`ui-src/types/penpotDocument.ts`, [ui-src/types/penpotDocument.tsL14-R14](diffhunk://#diff-13a1b54f751b461fd00b430f7d2d545360b8a9c5e9f220500586ae12f2dc1fb9L14-R14))
* Modified the `parse` function to only add the tokens library if tokens are present, preventing unnecessary operations when tokens are absent. (`ui-src/parser/parse.ts`, [ui-src/parser/parse.tsR32-R35](diffhunk://#diff-7ba96dd5776d8bd60e5f2222dcade0136c0c9eec3c4b9dd802cac0ba36bccc99R32-R35))

**Changelog:**

* Added a patch changelog entry describing the fix for the case where there are no variables in the Figma file. (`.changeset/nine-waves-boil.md`, [.changeset/nine-waves-boil.mdR1-R5](diffhunk://#diff-cfb7052b1d01cfbb38486a34aad22b8991f4978d9a828ad35949fb643dcc70c4R1-R5))

Closes #308 