### PR TITLE
Improve SVG parsing

### DIFF
--- a/.changeset/fresh-rivers-smoke.md
+++ b/.changeset/fresh-rivers-smoke.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Improve svg parsing


### PR DESCRIPTION
This pull request improves SVG path parsing and deduplication logic in the `transformVectorPaths` transformer, making the process more efficient and robust. The main changes focus on caching parsed SVG commands and vertices, switching from string-based normalization to geometric vertex comparison, and optimizing how vector paths and fill geometries are filtered and deduplicated.

**SVG Parsing and Deduplication Improvements:**

* Added caching for parsed SVG commands and extracted vertices to avoid redundant parsing and computation, improving performance when processing repeated path data.
* Replaced the old string-based path normalization with a vertex-based approach: vertices are extracted, rounded, and compared using hash sets, allowing for more accurate and efficient deduplication of vector paths and fill geometries.
* Updated the main filtering logic in `transformVectorPaths` to use hash-based deduplication (O(1) lookup) instead of O(n²) comparisons, and to compare combined vertices of vector paths and fill geometries for inclusion decisions.
* Refactored the transformation function to use the new cached command parser (`getParsedCommands`) instead of calling `parseSVG` directly.

**Project Metadata:**

* Updated the changeset to reflect a patch release for the `penpot-exporter` package, describing the improved SVG parsing.