### PR TITLE
Export current page instead of whole document

### DIFF
--- a/.changeset/free-plums-mate.md
+++ b/.changeset/free-plums-mate.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': minor
+---
+
+Add export scope option to choose between exporting all pages or only the current page.

--- a/plugin-src/code.ts
+++ b/plugin-src/code.ts
@@ -1,8 +1,17 @@
 import { getUserData } from '@plugin/getUserData';
 import { handleExportMessage, handleRetryMessage } from '@plugin/handleMessage';
 
+import type { ExportScope } from '@ui/types/progressMessages';
+
 const BASE_HEIGHT = 500;
 const BASE_WIDTH = 290;
+
+type ExportMessage = {
+  type: 'export';
+  data: {
+    scope: ExportScope;
+  };
+};
 
 const onMessage: MessageEventHandler = message => {
   if (message.type === 'ready') {
@@ -14,7 +23,9 @@ const onMessage: MessageEventHandler = message => {
   }
 
   if (message.type === 'export') {
-    handleExportMessage();
+    const exportMessage = message as ExportMessage;
+    const scope = exportMessage.data?.scope ?? 'all';
+    handleExportMessage(scope);
   }
 
   if (message.type === 'cancel') {

--- a/plugin-src/handleMessage.ts
+++ b/plugin-src/handleMessage.ts
@@ -11,9 +11,11 @@ import {
 import { transformDocumentNode } from '@plugin/transformers';
 import { flushProgress, reportProgress, resetProgress } from '@plugin/utils';
 
-export const handleExportMessage = async (): Promise<void> => {
+import type { ExportScope } from '@ui/types/progressMessages';
+
+export const handleExportMessage = async (scope: ExportScope): Promise<void> => {
   resetProgress();
-  const document = await transformDocumentNode(figma.root);
+  const document = await transformDocumentNode(figma.root, scope);
 
   flushProgress();
 

--- a/plugin-src/processors/processPages.ts
+++ b/plugin-src/processors/processPages.ts
@@ -4,22 +4,29 @@ import { transformPageNode } from '@plugin/transformers';
 import { flushProgress, reportProgress } from '@plugin/utils';
 
 import type { PenpotPage } from '@ui/lib/types/penpotPage';
+import type { ExportScope } from '@ui/types/progressMessages';
 
-export const processPages = async (node: DocumentNode): Promise<PenpotPage[]> => {
+export const processPages = async (
+  node: DocumentNode,
+  scope: ExportScope
+): Promise<PenpotPage[]> => {
   const children = [];
   let currentPage = 1;
+
+  // Get pages to process based on scope
+  const pagesToProcess = scope === 'current' ? [figma.currentPage] : node.children;
 
   reportProgress({
     type: 'PROGRESS_STEP',
     data: {
       step: 'processing',
-      total: node.children.length
+      total: pagesToProcess.length
     }
   });
 
   await yieldByTime(undefined, true);
 
-  for (const page of node.children) {
+  for (const page of pagesToProcess) {
     await page.loadAsync();
 
     children.push(await transformPageNode(page));

--- a/plugin-src/transformers/transformDocumentNode.ts
+++ b/plugin-src/transformers/transformDocumentNode.ts
@@ -10,14 +10,18 @@ import {
 import { processAssets } from '@plugin/processors/processAssets';
 
 import type { PenpotDocument } from '@ui/types';
+import type { ExportScope } from '@ui/types/progressMessages';
 
-export const transformDocumentNode = async (node: DocumentNode): Promise<PenpotDocument> => {
+export const transformDocumentNode = async (
+  node: DocumentNode,
+  scope: ExportScope
+): Promise<PenpotDocument> => {
   const tokens = await processTokens();
 
   await registerPaintStyles();
   await registerTextStyles();
 
-  const children = await processPages(node);
+  const children = await processPages(node, scope);
   const [images, paintStyles, textStyles] = await processAssets();
 
   return {

--- a/ui-src/components/ExportForm.tsx
+++ b/ui-src/components/ExportForm.tsx
@@ -1,15 +1,26 @@
-import { Button, Link, Muted } from '@create-figma-plugin/ui';
-import type { JSX } from 'preact';
+import type { SegmentedControlOption } from '@create-figma-plugin/ui';
+import { Button, Muted, SegmentedControl } from '@create-figma-plugin/ui';
+import type { JSX, TargetedEvent } from 'preact';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { Stack } from '@ui/components/Stack';
 import { useFigmaContext } from '@ui/context';
+import type { ExportScope } from '@ui/types/progressMessages';
 
 export type FormValues = Record<string, string>;
 
+const scopeOptions: SegmentedControlOption[] = [
+  { value: 'all', children: 'All pages' },
+  { value: 'current', children: 'Current page' }
+];
+
 export const ExportForm = (): JSX.Element => {
-  const { cancel, exportPenpot } = useFigmaContext();
+  const { cancel, exportPenpot, exportScope, setExportScope } = useFigmaContext();
   const methods = useForm<FormValues>();
+
+  const handleScopeChange = (event: TargetedEvent<HTMLInputElement>): void => {
+    setExportScope(event.currentTarget.value as ExportScope);
+  };
 
   return (
     <FormProvider {...methods}>
@@ -29,6 +40,21 @@ export const ExportForm = (): JSX.Element => {
           </Stack>
 
           <Stack space="xsmall">
+            <strong style={{ fontSize: 13 }}>Export scope</strong>
+            <div style={{ width: 'fit-content' }}>
+              <SegmentedControl
+                options={scopeOptions}
+                value={exportScope}
+                onChange={handleScopeChange}
+              />
+            </div>
+            <Muted>
+              For large documents, try exporting the current page first to test, then do a full
+              export.
+            </Muted>
+          </Stack>
+
+          <Stack space="xsmall">
             <strong style={{ fontSize: 13 }}>How it works</strong>
             <ol style={{ margin: 0, paddingLeft: '1.25rem' }}>
               <li style={{ marginBottom: '0.5rem' }}>
@@ -43,16 +69,6 @@ export const ExportForm = (): JSX.Element => {
               </li>
             </ol>
           </Stack>
-
-          <Muted>
-            Need a refresher on importing?{' '}
-            <Link
-              href="https://help.penpot.app/user-guide/import-export/#importing-files"
-              target="_blank"
-            >
-              Learn how →
-            </Link>
-          </Muted>
 
           <Stack space="xsmall" direction="row">
             <Button fullWidth>Start Export</Button>

--- a/ui-src/components/ExportSummary.tsx
+++ b/ui-src/components/ExportSummary.tsx
@@ -7,13 +7,15 @@ import { useFigmaContext } from '@ui/context';
 import { fileSizeInMB, formatExportTime } from '@ui/utils';
 
 export const ExportSummary = (): JSX.Element | null => {
-  const { exportedBlob, exportTime, missingFonts, downloadBlob, cancel } = useFigmaContext();
+  const { exportedBlob, exportTime, exportScope, missingFonts, downloadBlob, cancel } =
+    useFigmaContext();
 
   if (!exportedBlob) {
     return null;
   }
 
   const hasMissingFonts = missingFonts && missingFonts.length > 0;
+  const isCurrentPageOnly = exportScope === 'current';
 
   return (
     <Stack space="medium">
@@ -33,6 +35,13 @@ export const ExportSummary = (): JSX.Element | null => {
           )}
         </p>
       </Stack>
+
+      {isCurrentPageOnly && (
+        <Banner icon={<Info size={14} />}>
+          This export contains only the current page. Components and other pages are not included.
+          To export everything, select &quot;All pages&quot;.
+        </Banner>
+      )}
 
       {hasMissingFonts && (
         <Stack space="xsmall">

--- a/ui-src/types/progressMessages.ts
+++ b/ui-src/types/progressMessages.ts
@@ -1,5 +1,7 @@
 import type { PenpotDocument } from '@ui/types/penpotDocument';
 
+export type ExportScope = 'all' | 'current';
+
 export type Steps =
   | 'processing'
   | 'processAssets'


### PR DESCRIPTION
This pull request introduces a new feature allowing users to choose whether to export all pages or only the current page when exporting. The implementation includes updates to both the plugin and UI layers to support this export scope option, as well as user interface improvements to clarify the export scope and its implications.

**Export scope feature:**

* Added an `ExportScope` type (`'all' | 'current'`) and propagated it through the codebase to allow users to select between exporting all pages or just the current page. This affects the plugin message handling, document transformation, and page processing logic to respect the selected scope. [[1]](diffhunk://#diff-f4657bb4390f87f3374e6462e35a5a181c2a573947af446ea1b74a355dbd6e41R3-R4) [[2]](diffhunk://#diff-3a7120427f30f18a506f26778305ed1b1eb17f05effb5b37f076b1d0d683c2a4R4-R15) [[3]](diffhunk://#diff-3a7120427f30f18a506f26778305ed1b1eb17f05effb5b37f076b1d0d683c2a4L17-R28) [[4]](diffhunk://#diff-9073290b13a577910a57142c8be5204f5fbc3a8346706e94f6cd03cb60fdaf73L14-R18) [[5]](diffhunk://#diff-65156a321395f1c801ff983d0396ce6260da4c572655caa3609130e25647427aR7-R29) [[6]](diffhunk://#diff-0e814e93682b0942815350e90d8d0d6e768a9810952c046400848dc1b3a9dd84R13-R24)

**User interface enhancements:**

* Updated the export form (`ExportForm.tsx`) to include a segmented control for selecting the export scope, with explanatory text to guide users, and removed the previous help link. [[1]](diffhunk://#diff-4c841aa74f81f29e09910e290e143003761d05e76c11cf80398d1e95e7e65a5cL1-R24) [[2]](diffhunk://#diff-4c841aa74f81f29e09910e290e143003761d05e76c11cf80398d1e95e7e65a5cR42-R56) [[3]](diffhunk://#diff-4c841aa74f81f29e09910e290e143003761d05e76c11cf80398d1e95e7e65a5cL47-L56)
* Improved the export summary (`ExportSummary.tsx`) to display a banner when only the current page is exported, warning users that components and other pages are not included. [[1]](diffhunk://#diff-91fae8cf9da5fe8d3dcc2b52abf3e29f03bc2f98226cce733d3f88d302147177L10-R18) [[2]](diffhunk://#diff-91fae8cf9da5fe8d3dcc2b52abf3e29f03bc2f98226cce733d3f88d302147177R39-R45)

**State management and messaging:**

* Extended the `useFigma` context to track the selected export scope, reset it on cancel, and include it in analytics and plugin messages. [[1]](diffhunk://#diff-2dd8a5bec6de6926aab72c9c07b2733e3e6d177c8af469fd849c82f9dd8ba131L4-R7) [[2]](diffhunk://#diff-2dd8a5bec6de6926aab72c9c07b2733e3e6d177c8af469fd849c82f9dd8ba131R25-R29) [[3]](diffhunk://#diff-2dd8a5bec6de6926aab72c9c07b2733e3e6d177c8af469fd849c82f9dd8ba131R40) [[4]](diffhunk://#diff-2dd8a5bec6de6926aab72c9c07b2733e3e6d177c8af469fd849c82f9dd8ba131R76) [[5]](diffhunk://#diff-2dd8a5bec6de6926aab72c9c07b2733e3e6d177c8af469fd849c82f9dd8ba131L211-R216) [[6]](diffhunk://#diff-2dd8a5bec6de6926aab72c9c07b2733e3e6d177c8af469fd849c82f9dd8ba131R243-R244)

**Documentation:**

* Added a changeset documenting the addition of the export scope option.