### PR TITLE
View on board

### DIFF
--- a/.changeset/witty-oranges-type.md
+++ b/.changeset/witty-oranges-type.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Set hideInViewer true in Penpot when hide is active in Figma

--- a/plugin-src/transformers/transformComponentNode.ts
+++ b/plugin-src/transformers/transformComponentNode.ts
@@ -45,6 +45,7 @@ export const transformComponentNode = async (node: ComponentNode): Promise<Compo
   const component: ComponentShape = {
     type: 'component',
     showContent: !node.clipsContent,
+    hideInViewer: !node.visible,
     componentRoot: true,
     mainInstance: true,
     variantId,

--- a/plugin-src/transformers/transformFrameNode.ts
+++ b/plugin-src/transformers/transformFrameNode.ts
@@ -56,6 +56,7 @@ export const transformFrameNode = async (node: FrameNode | SectionNode): Promise
     type: 'frame',
     name: node.name,
     showContent: isSectionNode(node) ? true : !node.clipsContent,
+    hideInViewer: !node.visible,
     ...transformIds(node),
     ...transformFills(node),
     ...referencePoint,

--- a/plugin-src/transformers/transformInstanceNode.ts
+++ b/plugin-src/transformers/transformInstanceNode.ts
@@ -44,6 +44,7 @@ export const transformInstanceNode = async (
       : undefined,
     componentRoot: isComponentRoot(node),
     showContent: !node.clipsContent,
+    hideInViewer: !node.visible,
     isOrphan,
     ...transformInstanceIds(node, mainComponent),
     ...transformFills(node),

--- a/tests/plugin-src/transformers/artboardVisibility.test.ts
+++ b/tests/plugin-src/transformers/artboardVisibility.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAllState } from '@plugin/libraries';
+import { transformComponentNode } from '@plugin/transformers/transformComponentNode';
+import { transformFrameNode } from '@plugin/transformers/transformFrameNode';
+import { transformInstanceNode } from '@plugin/transformers/transformInstanceNode';
+
+vi.mock('@plugin/transformers/partials', () => ({
+  transformAutoLayout: (): Record<string, never> => ({}),
+  transformBlend: (): Record<string, never> => ({}),
+  transformChildren: async (): Promise<{ children: never[] }> => ({ children: [] }),
+  transformConstraints: (): Record<string, never> => ({}),
+  transformCornerRadius: (): Record<string, never> => ({}),
+  transformDimension: (): { width: number; height: number } => ({
+    width: 100,
+    height: 100
+  }),
+  transformEffects: (): Record<string, never> => ({}),
+  transformFills: (): { fills: never[] } => ({ fills: [] }),
+  transformGrids: (): Record<string, never> => ({}),
+  transformId: (): string => 'variant-id',
+  transformIds: (): { id: string; shapeRef: undefined } => ({
+    id: 'frame-id',
+    shapeRef: undefined
+  }),
+  transformComponentIds: (): { id: string; componentId: string } => ({
+    id: 'component-shape-id',
+    componentId: 'component-id'
+  }),
+  transformComponentNameAndPath: (): { name: string; path: string } => ({
+    name: 'Component',
+    path: 'Library/Component'
+  }),
+  transformInstanceIds: (): { id: string; shapeRef: undefined; componentId: string } => ({
+    id: 'instance-id',
+    shapeRef: undefined,
+    componentId: 'component-id'
+  }),
+  transformLayoutAttributes: (): Record<string, never> => ({}),
+  transformOverrides: (): Record<string, never> => ({}),
+  transformProportion: (): Record<string, never> => ({}),
+  transformRotationAndPosition: (): { x: number; y: number } => ({
+    x: 10,
+    y: 20
+  }),
+  transformSceneNode: (node: {
+    locked?: boolean;
+    visible: boolean;
+  }): {
+    blocked: boolean;
+    hidden: boolean;
+  } => ({
+    blocked: Boolean(node.locked),
+    hidden: !node.visible
+  }),
+  transformStrokes: (): { strokes: never[] } => ({ strokes: [] }),
+  transformVariableConsumptionMap: (): Record<string, never> => ({}),
+  transformVariantNameAndProperties: (): Record<string, never> => ({})
+}));
+
+vi.mock('@plugin/translators/components', () => ({
+  registerComponentProperties: vi.fn()
+}));
+
+const createFrameNode = (visible: boolean): FrameNode => {
+  return {
+    id: '1:1',
+    name: 'Frame',
+    type: 'FRAME',
+    visible,
+    locked: false,
+    clipsContent: false,
+    absoluteTransform: [
+      [1, 0, 10],
+      [0, 1, 20]
+    ]
+  } as unknown as FrameNode;
+};
+
+const createComponentNode = (visible: boolean): ComponentNode => {
+  return {
+    id: '2:1',
+    key: 'component-key',
+    name: 'Component',
+    type: 'COMPONENT',
+    visible,
+    locked: false,
+    clipsContent: false,
+    parent: null,
+    setPluginData: vi.fn(),
+    getPublishStatusAsync: vi.fn().mockResolvedValue('UNPUBLISHED')
+  } as unknown as ComponentNode;
+};
+
+const createMainComponent = (): ComponentNode => {
+  return {
+    id: '3:1',
+    key: 'main-component-key',
+    name: 'Main component',
+    type: 'COMPONENT',
+    visible: true,
+    locked: false,
+    remote: false,
+    parent: {} as BaseNode,
+    getPluginData: vi.fn().mockReturnValue('')
+  } as unknown as ComponentNode;
+};
+
+const createInstanceNode = (visible: boolean, mainComponent: ComponentNode): InstanceNode => {
+  return {
+    id: 'I4:1',
+    name: 'Instance',
+    type: 'INSTANCE',
+    visible,
+    locked: false,
+    clipsContent: false,
+    overrides: [],
+    parent: null,
+    getMainComponentAsync: vi.fn().mockResolvedValue(mainComponent)
+  } as unknown as InstanceNode;
+};
+
+describe('artboard visibility export', () => {
+  beforeEach(() => {
+    clearAllState();
+
+    // @ts-expect-error - Mocking global figma object for transformer tests
+    global.figma = {
+      root: {
+        name: 'Test file'
+      }
+    };
+  });
+
+  it('sets hideInViewer when a frame is hidden in Figma', async () => {
+    const result = await transformFrameNode(createFrameNode(false));
+
+    expect(result.hidden).toBe(true);
+    expect(result.hideInViewer).toBe(true);
+  });
+
+  it('sets hideInViewer when a component is hidden in Figma', async () => {
+    const result = await transformComponentNode(createComponentNode(false));
+
+    expect(result.hidden).toBe(true);
+    expect(result.hideInViewer).toBe(true);
+  });
+
+  it('sets hideInViewer when an instance is hidden in Figma', async () => {
+    const mainComponent = createMainComponent();
+    const result = await transformInstanceNode(createInstanceNode(false, mainComponent));
+
+    expect(result).toBeDefined();
+    expect(result?.hidden).toBe(true);
+    expect(result?.hideInViewer).toBe(true);
+  });
+});

--- a/ui-src/lib/types/shapes/componentShape.ts
+++ b/ui-src/lib/types/shapes/componentShape.ts
@@ -22,6 +22,7 @@ type ComponentAttributes = {
   type?: 'component';
   path: string;
   showContent?: boolean;
+  hideInViewer?: boolean;
   mainInstanceId?: Uuid;
   mainInstancePage?: Uuid;
 };

--- a/ui-src/types/component.ts
+++ b/ui-src/types/component.ts
@@ -29,6 +29,7 @@ export type ComponentInstance = ShapeBaseAttributes &
   Children & {
     componentRoot: boolean;
     showContent?: boolean;
+    hideInViewer?: boolean;
     isOrphan: boolean;
     type: 'instance';
   };


### PR DESCRIPTION
## Summary

  Fixes the export of hidden Figma frames/components/instances so Penpot also receives the correct
  presentation visibility.

  Until now, when a node was hidden in Figma, we correctly exported it as `hidden`, but Penpot still
  received its `hideInViewer` / "Show in view mode" state as visible. That caused a mismatch between editor
  visibility and presentation behavior after import.

  ## What changed

  - Set `hideInViewer` to `true` when a Figma frame is exported with `visible === false`
  - Apply the same behavior to components and instances, since they are also exported as artboards/boards in
  Penpot
  - Update the related shape types so the new property is represented explicitly
  - Add regression tests covering hidden frame, component, and instance exports

  ## Why this change

  Penpot treats `hidden` and "Show in view mode" separately.

  For parity with Figma behavior, if a node is hidden in Figma, it should also be hidden in Penpot
  presentation/view mode. This change keeps both states aligned and prevents hidden content from
  unexpectedly appearing in presentation flows.

  ## Scope

  This change is intentionally minimal:

  - No changes to generic scene-node visibility handling
  - No changes to shapes that are not exported as Penpot boards
  - Only board-producing transformers were updated

  ## Testing

  - Added regression tests for:
    - hidden frame export
    - hidden component export
    - hidden instance export
  - Ran `npm run test:run`
  - Ran `npm run lint`

  ## Result

  Hidden frames/components/instances exported from Figma now arrive in Penpot with both:

  - `hidden` set correctly
  - `hideInViewer` set correctly

  This keeps editor visibility and presentation visibility consistent after import.