### PR TITLE
Fetch collection variables in parallel

### DIFF
--- a/plugin-src/processors/processTokens.ts
+++ b/plugin-src/processors/processTokens.ts
@@ -148,7 +148,7 @@ const getVariables = async (collection: VariableCollection): Promise<Variable[]>
     collection.variableIds.map(id => figma.variables.getVariableByIdAsync(id))
   );
 
-  return results.filter((v): v is Variable => v !== null);
+  return results.filter((v): v is Variable => !!v);
 };
 
 export const processTokens = async (): Promise<Tokens | undefined> => {

--- a/plugin-src/processors/processTokens.ts
+++ b/plugin-src/processors/processTokens.ts
@@ -144,17 +144,11 @@ const resolveAliases = async (sets: TokenSets): Promise<TokenSets> => {
 };
 
 const getVariables = async (collection: VariableCollection): Promise<Variable[]> => {
-  const variables: Variable[] = [];
+  const results = await Promise.all(
+    collection.variableIds.map(id => figma.variables.getVariableByIdAsync(id))
+  );
 
-  for (const variableId of collection.variableIds) {
-    const variable = await figma.variables.getVariableByIdAsync(variableId);
-
-    if (!variable) continue;
-
-    variables.push(variable);
-  }
-
-  return variables;
+  return results.filter((v): v is Variable => v !== null);
 };
 
 export const processTokens = async (): Promise<Tokens | undefined> => {


### PR DESCRIPTION
## Summary

  Replace the sequential `for…of await` over `collection.variableIds` in `processTokens.getVariables` with `Promise.all`. Each `figma.variables.getVariableByIdAsync` call is independent, so serializing
  them was leaving significant wall-time on the table — especially for collections whose variables resolve through external/team libraries, where each round-trip carries metadata work on top of the
  bridge latency.

  ## Measurements

  Measured on a real design system with 4 variable collections (775 variables total, one of them backed by an external library):

  | Collection | N | Before | After | Speedup |
  |---|---|---|---|---|
  | TailwindCSS (external library) | 452 | 1826 ms | 183 ms | **10.0×** |
  | Theme | 235 | 45 ms | 47 ms | ~1× |
  | Mode | 62 | 12 ms | 13 ms | ~1× |
  | Custom | 26 | 6 ms | 6 ms | 1× |
  | **Total** | 775 | **1889 ms** | **249 ms** | **7.6×** |

  Collections whose variables resolve locally were already at the noise floor — their cost is dominated by host-side work, not the bridge round-trip. The 10× speedup shows up where it matters most:
  collections backed by team libraries.