### PR TITLE
Convert slot to frame

### DIFF
--- a/.changeset/late-animals-ask.md
+++ b/.changeset/late-animals-ask.md
@@ -1,0 +1,7 @@
+---
+'penpot-exporter': minor
+---
+
+Export Figma slots as frames (temporary workaround until Penpot supports slots natively):
+preserves slot contents that were previously dropped from the export, rendered as regular frames without slot
+semantics.

--- a/.changeset/late-animals-ask.md
+++ b/.changeset/late-animals-ask.md
@@ -3,5 +3,4 @@
 ---
 
 Export Figma slots as frames (temporary workaround until Penpot supports slots natively):
-preserves slot contents that were previously dropped from the export, rendered as regular frames without slot
-semantics.
+preserves slot contents that were previously dropped from the export, rendered as regular frames without slot semantics.

--- a/plugin-src/transformers/transformFrameNode.ts
+++ b/plugin-src/transformers/transformFrameNode.ts
@@ -21,11 +21,15 @@ import {
 import type { FrameShape } from '@ui/lib/types/shapes/frameShape';
 import type { Point } from '@ui/lib/types/utils/point';
 
-const isSectionNode = (node: FrameNode | SectionNode | ComponentSetNode): node is SectionNode => {
+const isSectionNode = (
+  node: FrameNode | SectionNode | SlotNode | ComponentSetNode
+): node is SectionNode => {
   return node.type === 'SECTION';
 };
 
-export const transformFrameNode = async (node: FrameNode | SectionNode): Promise<FrameShape> => {
+export const transformFrameNode = async (
+  node: FrameNode | SectionNode | SlotNode
+): Promise<FrameShape> => {
   let frameSpecificAttributes: Partial<FrameShape> = {};
   let referencePoint: Point = { x: node.absoluteTransform[0][2], y: node.absoluteTransform[1][2] };
 

--- a/plugin-src/transformers/transformSceneNode.ts
+++ b/plugin-src/transformers/transformSceneNode.ts
@@ -36,6 +36,7 @@ export const transformSceneNode = async (node: SceneNode): Promise<PenpotNode | 
       break;
     case 'SECTION':
     case 'FRAME':
+    case 'SLOT':
       penpotNode = await transformFrameNode(node);
       break;
     case 'GROUP':

--- a/tests/plugin-src/transformers/slotNode.test.ts
+++ b/tests/plugin-src/transformers/slotNode.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { clearAllState } from '@plugin/libraries';
+import { transformFrameNode } from '@plugin/transformers/transformFrameNode';
+import { transformSceneNode } from '@plugin/transformers/transformSceneNode';
+
+vi.mock('@plugin/transformers/partials', () => ({
+  transformAutoLayout: (): Record<string, never> => ({}),
+  transformBlend: (): Record<string, never> => ({}),
+  transformChildren: async (): Promise<{ children: never[] }> => ({ children: [] }),
+  transformConstraints: (): Record<string, never> => ({}),
+  transformCornerRadius: (): Record<string, never> => ({}),
+  transformDimension: (): { width: number; height: number } => ({
+    width: 100,
+    height: 100
+  }),
+  transformEffects: (): Record<string, never> => ({}),
+  transformFills: (): { fills: never[] } => ({ fills: [] }),
+  transformGrids: (): Record<string, never> => ({}),
+  transformIds: (): { id: string; shapeRef: undefined } => ({
+    id: 'slot-id',
+    shapeRef: undefined
+  }),
+  transformLayoutAttributes: (): Record<string, never> => ({}),
+  transformOverrides: (): Record<string, never> => ({}),
+  transformProportion: (): Record<string, never> => ({}),
+  transformRotationAndPosition: (): { x: number; y: number } => ({
+    x: 10,
+    y: 20
+  }),
+  transformSceneNode: (node: {
+    locked?: boolean;
+    visible: boolean;
+  }): {
+    blocked: boolean;
+    hidden: boolean;
+  } => ({
+    blocked: Boolean(node.locked),
+    hidden: !node.visible
+  }),
+  transformStrokes: (): { strokes: never[] } => ({ strokes: [] }),
+  transformVariableConsumptionMap: (): Record<string, never> => ({})
+}));
+
+const createSlotNode = (): SlotNode => {
+  return {
+    id: '5:1',
+    name: 'Icon slot',
+    type: 'SLOT',
+    visible: true,
+    locked: false,
+    clipsContent: false,
+    absoluteTransform: [
+      [1, 0, 10],
+      [0, 1, 20]
+    ]
+  } as unknown as SlotNode;
+};
+
+describe('slot node export', () => {
+  beforeEach(() => {
+    clearAllState();
+
+    // @ts-expect-error - Mocking global figma object for transformer tests
+    global.figma = {
+      root: {
+        name: 'Test file'
+      }
+    };
+  });
+
+  it('routes SLOT nodes through transformFrameNode when reached via transformSceneNode', async () => {
+    const result = await transformSceneNode(createSlotNode() as unknown as SceneNode);
+
+    expect(result).toBeDefined();
+    expect(result?.type).toBe('frame');
+  });
+
+  it('transformFrameNode accepts a SlotNode and produces a FrameShape', async () => {
+    const result = await transformFrameNode(createSlotNode());
+
+    expect(result.type).toBe('frame');
+    expect(result.name).toBe('Icon slot');
+  });
+});


### PR DESCRIPTION
## Summary

  Figma's `SlotNode` (frame inside a component that can hold freeform content, created via `⌘⇧S` / "Convert to slot") was being silently dropped on
  export. Because `transformSceneNode.ts` had no `case 'SLOT'` in its switch, slot nodes — and all of their children — were discarded, producing Penpot
   files missing visible content from components that used slots.

  This PR treats `SlotNode` as a frame on export. Penpot does not yet have a native slot concept, but `SlotNode extends DefaultFrameMixin` (same base
  as `FrameNode`), so the contents render correctly as a regular frame on the Penpot side.

  ## What changed

  - `plugin-src/transformers/transformSceneNode.ts` — added `case 'SLOT'` routing to `transformFrameNode`, alongside `'FRAME'` and `'SECTION'`.
  - `plugin-src/transformers/transformFrameNode.ts` — widened `transformFrameNode` and the `isSectionNode` guard to accept `SlotNode` (no body changes
  needed since the partials already accept `DefaultFrameMixin`).
  - `tests/plugin-src/transformers/slotNode.test.ts` — new unit tests verifying (1) `transformSceneNode` routes a `SLOT` node through
  `transformFrameNode` and (2) `transformFrameNode` accepts a `SlotNode` and produces a `FrameShape`.

  The filter in `registerComponentProperties.ts` is intentionally left as-is: Penpot doesn't consume the `SLOT` property metadata (the UI parser only
  reads `visible`/`characters` references). When Penpot eventually supports slots natively, the metadata path can be reopened and a dedicated shape
  type added.