### PR TITLE
Improve error handling

### DIFF
--- a/.changeset/export-error-capture.md
+++ b/.changeset/export-error-capture.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Show an error screen instead of freezing when an export fails.

--- a/plugin-src/code.ts
+++ b/plugin-src/code.ts
@@ -1,5 +1,5 @@
 import { getUserData } from '@plugin/getUserData';
-import { handleExportMessage, handleRetryMessage } from '@plugin/handleMessage';
+import { handleExportMessage, handleRetryMessage, postPluginError } from '@plugin/handleMessage';
 import { isSlidesEditor } from '@plugin/utils';
 
 import type { ExportScope, ExternalLibrary } from '@ui/types';
@@ -23,31 +23,35 @@ const sendEditorType = (): void => {
 };
 
 const onMessage: MessageEventHandler = message => {
-  if (message.type === 'ready') {
-    getUserData();
-    sendEditorType();
-  }
+  try {
+    if (message.type === 'ready') {
+      getUserData();
+      sendEditorType();
+    }
 
-  if (message.type === 'retry') {
-    handleRetryMessage();
-  }
+    if (message.type === 'retry') {
+      handleRetryMessage();
+    }
 
-  if (message.type === 'export') {
-    const exportMessage = message as ExportMessage;
-    const scope = exportMessage.data?.scope ?? 'all';
-    const libraries = exportMessage.data?.libraries ?? [];
+    if (message.type === 'export') {
+      const exportMessage = message as ExportMessage;
+      const scope = exportMessage.data?.scope ?? 'all';
+      const libraries = exportMessage.data?.libraries ?? [];
 
-    handleExportMessage(scope, libraries);
-  }
+      handleExportMessage(scope, libraries);
+    }
 
-  if (message.type === 'cancel') {
-    figma.closePlugin();
-  }
+    if (message.type === 'cancel') {
+      figma.closePlugin();
+    }
 
-  if (message.type === 'resize') {
-    const width = message.width ?? BASE_WIDTH;
-    const height = message.height ?? BASE_HEIGHT;
-    figma.ui.resize(width, height);
+    if (message.type === 'resize') {
+      const width = message.width ?? BASE_WIDTH;
+      const height = message.height ?? BASE_HEIGHT;
+      figma.ui.resize(width, height);
+    }
+  } catch (error) {
+    postPluginError(error);
   }
 };
 

--- a/plugin-src/handleMessage.ts
+++ b/plugin-src/handleMessage.ts
@@ -11,9 +11,16 @@ import {
   variantProperties
 } from '@plugin/libraries';
 import { transformDocumentNode, transformSlidesDocumentNode } from '@plugin/transformers';
-import { flushProgress, isSlidesEditor, reportProgress, resetProgress } from '@plugin/utils';
+import {
+  flushProgress,
+  getCurrentItem,
+  getCurrentStep,
+  isSlidesEditor,
+  reportProgress,
+  resetProgress
+} from '@plugin/utils';
 
-import type { ExportScope, ExternalLibrary } from '@ui/types';
+import type { ErrorPayload, ExportScope, ExternalLibrary } from '@ui/types';
 
 const initializeExternalLibraries = (libraries: ExternalLibrary[]): void => {
   for (const library of libraries) {
@@ -21,39 +28,64 @@ const initializeExternalLibraries = (libraries: ExternalLibrary[]): void => {
   }
 };
 
+const buildErrorPayload = (error: unknown): ErrorPayload => ({
+  message: error instanceof Error ? error.message : String(error),
+  stack: error instanceof Error ? error.stack : undefined,
+  step: getCurrentStep(),
+  layer: getCurrentItem(),
+  origin: 'plugin'
+});
+
+export const postPluginError = (error: unknown): void => {
+  console.error('Penpot Exporter: unhandled error', error);
+  figma.ui.postMessage({
+    type: 'ERROR',
+    data: buildErrorPayload(error)
+  });
+};
+
 export const handleExportMessage = async (
   scope: ExportScope,
   libraries: ExternalLibrary[]
 ): Promise<void> => {
-  // Clear all state maps and caches to prevent memory accumulation
-  clearAllState();
-  resetProgress();
+  try {
+    // Clear all state maps and caches to prevent memory accumulation
+    clearAllState();
+    resetProgress();
 
-  initializeExternalLibraries(libraries);
-  const document = isSlidesEditor()
-    ? await transformSlidesDocumentNode(figma.root)
-    : await transformDocumentNode(figma.root, scope);
+    initializeExternalLibraries(libraries);
+    const document = isSlidesEditor()
+      ? await transformSlidesDocumentNode(figma.root)
+      : await transformDocumentNode(figma.root, scope);
 
-  flushProgress();
+    flushProgress();
 
-  reportProgress({
-    type: 'PENPOT_DOCUMENT',
-    data: document
-  });
+    reportProgress({
+      type: 'PENPOT_DOCUMENT',
+      data: document
+    });
+  } catch (error) {
+    flushProgress();
+    postPluginError(error);
+  }
 };
 
 export const handleRetryMessage = async (): Promise<void> => {
-  resetProgress();
-  missingFonts.clear();
-  textStyles.clear();
-  paintStyles.clear();
-  overrides.clear();
-  images.clear();
-  components.clear();
-  componentProperties.clear();
-  variantProperties.clear();
+  try {
+    resetProgress();
+    missingFonts.clear();
+    textStyles.clear();
+    paintStyles.clear();
+    overrides.clear();
+    images.clear();
+    components.clear();
+    componentProperties.clear();
+    variantProperties.clear();
 
-  reportProgress({
-    type: 'RELOAD'
-  });
+    reportProgress({
+      type: 'RELOAD'
+    });
+  } catch (error) {
+    postPluginError(error);
+  }
 };

--- a/plugin-src/utils/progress.ts
+++ b/plugin-src/utils/progress.ts
@@ -1,10 +1,12 @@
 import { createMessageBuffer } from '@common/messageBuffer';
 
-import { BUFFERED_PROGRESS_TYPES, type PluginMessage } from '@ui/types';
+import { BUFFERED_PROGRESS_TYPES, type PluginMessage, type Steps } from '@ui/types';
 
 const BUFFERED_TYPES = new Set(BUFFERED_PROGRESS_TYPES);
 
 let lastSentCurrentItem: string | undefined;
+let currentStep: Steps | undefined;
+let currentItem: string | undefined;
 
 const messageBuffer = createMessageBuffer<PluginMessage>({
   bufferedTypes: BUFFERED_TYPES,
@@ -23,13 +25,24 @@ export const flushProgress = (): void => {
 
 export const resetProgress = (): void => {
   lastSentCurrentItem = undefined;
+  currentStep = undefined;
+  currentItem = undefined;
 };
 
 export const reportProgress = (message: PluginMessage): void => {
-  // Skip sending PROGRESS_CURRENT_ITEM if it's the same as the last sent value
-  if (message.type === 'PROGRESS_CURRENT_ITEM' && message.data === lastSentCurrentItem) {
-    return;
+  if (message.type === 'PROGRESS_STEP') {
+    currentStep = message.data.step;
+  }
+
+  if (message.type === 'PROGRESS_CURRENT_ITEM') {
+    if (message.data === lastSentCurrentItem) {
+      return;
+    }
+    currentItem = message.data;
   }
 
   messageBuffer.send(message);
 };
+
+export const getCurrentStep = (): Steps | undefined => currentStep;
+export const getCurrentItem = (): string | undefined => currentItem;

--- a/tests/plugin-src/handleMessage.test.ts
+++ b/tests/plugin-src/handleMessage.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { handleExportMessage as HandleExportMessageFn } from '@plugin/handleMessage';
+import type * as PluginUtils from '@plugin/utils';
+
+const mockPostMessage = vi.fn();
+const mockTransformDocumentNode = vi.fn();
+const mockTransformSlidesDocumentNode = vi.fn();
+const mockIsSlidesEditor = vi.fn().mockReturnValue(false);
+
+vi.mock('@plugin/transformers', () => ({
+  transformDocumentNode: mockTransformDocumentNode,
+  transformSlidesDocumentNode: mockTransformSlidesDocumentNode
+}));
+
+vi.mock('@plugin/utils', async () => {
+  const actual = await vi.importActual<typeof PluginUtils>('@plugin/utils');
+  return {
+    ...actual,
+    isSlidesEditor: (): boolean => mockIsSlidesEditor()
+  };
+});
+
+(globalThis as { figma?: typeof figma }).figma = {
+  ui: { postMessage: mockPostMessage },
+  root: {} as typeof figma.root
+} as unknown as typeof figma;
+
+describe('handleExportMessage', () => {
+  let handleExportMessage: typeof HandleExportMessageFn;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockPostMessage.mockClear();
+    mockTransformDocumentNode.mockReset();
+    mockTransformSlidesDocumentNode.mockReset();
+    mockIsSlidesEditor.mockReturnValue(false);
+
+    const module = await import('@plugin/handleMessage');
+    handleExportMessage = module.handleExportMessage;
+  });
+
+  it('posts PENPOT_DOCUMENT on success', async () => {
+    mockTransformDocumentNode.mockResolvedValue({ name: 'doc' });
+
+    await handleExportMessage('all', []);
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'PENPOT_DOCUMENT' })
+    );
+  });
+
+  it('posts ERROR when transformer throws', async () => {
+    mockTransformDocumentNode.mockRejectedValue(new Error('boom'));
+
+    await handleExportMessage('all', []);
+
+    const errorCalls = mockPostMessage.mock.calls.filter(([msg]) => msg.type === 'ERROR');
+    expect(errorCalls).toHaveLength(1);
+    expect(errorCalls[0][0]).toEqual({
+      type: 'ERROR',
+      data: expect.objectContaining({
+        message: 'boom',
+        origin: 'plugin',
+        stack: expect.any(String)
+      })
+    });
+  });
+
+  it('posts ERROR with string when non-Error thrown', async () => {
+    mockTransformDocumentNode.mockRejectedValue('plain string failure');
+
+    await handleExportMessage('all', []);
+
+    const errorCalls = mockPostMessage.mock.calls.filter(([msg]) => msg.type === 'ERROR');
+    expect(errorCalls).toHaveLength(1);
+    expect(errorCalls[0][0]).toEqual({
+      type: 'ERROR',
+      data: expect.objectContaining({
+        message: 'plain string failure',
+        origin: 'plugin',
+        stack: undefined
+      })
+    });
+  });
+
+  it('routes to slides transformer when editor is slides', async () => {
+    mockIsSlidesEditor.mockReturnValue(true);
+    mockTransformSlidesDocumentNode.mockResolvedValue({ name: 'slides-doc' });
+
+    await handleExportMessage('all', []);
+
+    expect(mockTransformSlidesDocumentNode).toHaveBeenCalled();
+    expect(mockTransformDocumentNode).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ui-src/utils/formatErrorReport.test.ts
+++ b/tests/ui-src/utils/formatErrorReport.test.ts
@@ -1,0 +1,90 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import type { ErrorPayload } from '@ui/types';
+import { buildErrorIssueUrl, formatErrorReport } from '@ui/utils/formatErrorReport';
+
+(globalThis as { APP_VERSION?: string }).APP_VERSION = '0.22.0';
+
+const basePayload: ErrorPayload = {
+  message: 'boom',
+  origin: 'plugin'
+};
+
+describe('formatErrorReport', () => {
+  beforeAll(() => {
+    (globalThis as { APP_VERSION?: string }).APP_VERSION = '0.22.0';
+  });
+
+  it('includes plugin version and editor type', () => {
+    const report = formatErrorReport(basePayload, 'figma');
+
+    expect(report).toContain('Plugin version: 0.22.0');
+    expect(report).toContain('File type: figma');
+    expect(report).toContain('Message: boom');
+  });
+
+  it('omits step and layer when missing', () => {
+    const report = formatErrorReport(basePayload, 'figma');
+
+    expect(report).not.toContain('Step:');
+    expect(report).not.toContain('Layer:');
+  });
+
+  it('includes step and layer when present', () => {
+    const report = formatErrorReport(
+      { ...basePayload, step: 'processing', layer: 'Vector' },
+      'figma'
+    );
+
+    expect(report).toContain('Step: processing');
+    expect(report).toContain('Layer: Vector');
+  });
+
+  it('includes stack when present', () => {
+    const report = formatErrorReport(
+      { ...basePayload, stack: 'Error: boom\n    at foo:1:1' },
+      'figma'
+    );
+
+    expect(report).toContain('Stack:');
+    expect(report).toContain('at foo:1:1');
+  });
+
+  it('reflects non-figma editor type', () => {
+    const report = formatErrorReport(basePayload, 'slides');
+
+    expect(report).toContain('File type: slides');
+  });
+});
+
+describe('buildErrorIssueUrl', () => {
+  it('points to the project issues new endpoint', () => {
+    const url = buildErrorIssueUrl('any report');
+
+    expect(url).toMatch(
+      /^https:\/\/github\.com\/penpot\/penpot-exporter-figma-plugin\/issues\/new\?title=/
+    );
+  });
+
+  it('URL-encodes the report into the body', () => {
+    const url = buildErrorIssueUrl('line one\nline two');
+    const body = decodeURIComponent(url.split('&body=')[1] ?? '');
+
+    expect(body).toContain('line one\nline two');
+  });
+
+  it('asks for the .fig file in the issue body', () => {
+    const url = buildErrorIssueUrl('report');
+    const body = decodeURIComponent(url.split('&body=')[1] ?? '');
+
+    expect(body).toContain('.fig');
+    expect(body).toContain('attach');
+  });
+
+  it('uses a stable issue title', () => {
+    const url = buildErrorIssueUrl('report');
+    const title = decodeURIComponent(url.split('title=')[1]?.split('&')[0] ?? '');
+
+    expect(title).toBe('Export error');
+  });
+});

--- a/ui-src/components/FatalErrorFallback.tsx
+++ b/ui-src/components/FatalErrorFallback.tsx
@@ -1,0 +1,45 @@
+import { Banner, Button, Link } from '@create-figma-plugin/ui';
+import { CircleAlert } from 'lucide-react';
+import type { JSX } from 'preact';
+
+import { Stack } from '@ui/components/Stack';
+import { ERROR_ISSUES_URL, buildErrorIssueUrl, formatErrorReport } from '@ui/utils';
+
+type Props = {
+  error: Error;
+};
+
+export const FatalErrorFallback = ({ error }: Props): JSX.Element => {
+  const report = formatErrorReport(
+    { message: error.message, stack: error.stack, origin: 'ui' },
+    'figma'
+  );
+  const issueUrl = buildErrorIssueUrl(report);
+
+  const reload = (): void => {
+    window.location.reload();
+  };
+
+  return (
+    <div style={{ padding: '16px' }}>
+      <Stack space="small">
+        <Banner icon={<CircleAlert size={14} />} variant="warning">
+          The plugin crashed unexpectedly.
+        </Banner>
+        <span>
+          Please{' '}
+          <Link href={issueUrl} target="_blank">
+            open an issue in our Github repository →
+          </Link>{' '}
+          so we can fix this.
+        </span>
+        <Button onClick={reload} fullWidth>
+          Reload plugin
+        </Button>
+        <Link href={`${ERROR_ISSUES_URL}/new`} target="_blank">
+          Or open a blank issue
+        </Link>
+      </Stack>
+    </div>
+  );
+};

--- a/ui-src/components/LibraryError.tsx
+++ b/ui-src/components/LibraryError.tsx
@@ -1,12 +1,65 @@
 import { Banner, Button, Link } from '@create-figma-plugin/ui';
 import { CircleAlert } from 'lucide-react';
 import type { JSX } from 'preact';
+import { useState } from 'preact/hooks';
 
 import { Stack } from '@ui/components/Stack';
 import { useFigmaContext } from '@ui/context';
+import type { ErrorPayload } from '@ui/types';
+import { ERROR_ISSUES_URL, buildErrorIssueUrl, formatErrorReport } from '@ui/utils';
+
+const ErrorDetails = ({
+  error,
+  editorType
+}: {
+  error: ErrorPayload;
+  editorType: string;
+}): JSX.Element => {
+  const [copied, setCopied] = useState(false);
+  const report = formatErrorReport(error, editorType);
+
+  const handleCopy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(report);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <Stack space="xsmall">
+      <pre
+        style={{
+          margin: 0,
+          padding: '8px',
+          background: 'var(--figma-color-bg-secondary)',
+          border: '1px solid var(--figma-color-border)',
+          borderRadius: '4px',
+          fontSize: '11px',
+          fontFamily: 'monospace',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          maxHeight: '180px',
+          overflow: 'auto'
+        }}
+      >
+        {report}
+      </pre>
+      <Button secondary onClick={handleCopy} fullWidth>
+        {copied ? 'Copied!' : 'Copy error details'}
+      </Button>
+    </Stack>
+  );
+};
 
 export const LibraryError = (): JSX.Element => {
-  const { retry, cancel } = useFigmaContext();
+  const { retry, cancel, error, editorType } = useFigmaContext();
+
+  const issueUrl = error
+    ? buildErrorIssueUrl(formatErrorReport(error, editorType))
+    : `${ERROR_ISSUES_URL}/new`;
 
   return (
     <Stack space="small">
@@ -15,15 +68,18 @@ export const LibraryError = (): JSX.Element => {
           Oops! It looks like there was an <b>error generating the export file</b>.
         </Banner>
         <span>
-          Please open an issue in our{' '}
-          <Link
-            href="https://github.com/penpot/penpot-exporter-figma-plugin/issues"
-            target="_blank"
-          >
-            Github repository →
-          </Link>
-          , and we&apos;ll be happy to assist you!
+          Please{' '}
+          <Link href={issueUrl} target="_blank">
+            open an issue in our Github repository →
+          </Link>{' '}
+          and we&apos;ll be happy to assist you!
         </span>
+        <span style={{ fontSize: '11px', opacity: 0.8 }}>
+          <b>Tip:</b> attaching the <code>.fig</code> file (or a minimal reproduction) helps us fix
+          this much faster. If it&apos;s confidential, mention it in the issue and we&apos;ll
+          arrange a private channel.
+        </span>
+        {error && <ErrorDetails error={error} editorType={editorType} />}
         <Stack space="xsmall" direction="row">
           <Button onClick={retry} fullWidth>
             Retry

--- a/ui-src/components/LibraryError.tsx
+++ b/ui-src/components/LibraryError.tsx
@@ -8,6 +8,38 @@ import { useFigmaContext } from '@ui/context';
 import type { ErrorPayload } from '@ui/types';
 import { ERROR_ISSUES_URL, buildErrorIssueUrl, formatErrorReport } from '@ui/utils';
 
+const copyTextToClipboard = async (text: string): Promise<boolean> => {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Falls through to legacy fallback below (Figma iframe usually blocks clipboard API).
+    }
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '0';
+  textarea.style.left = '0';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+
+  let succeeded = false;
+  try {
+    succeeded = document.execCommand('copy');
+  } catch {
+    succeeded = false;
+  }
+
+  document.body.removeChild(textarea);
+  return succeeded;
+};
+
 const ErrorDetails = ({
   error,
   editorType
@@ -15,17 +47,13 @@ const ErrorDetails = ({
   error: ErrorPayload;
   editorType: string;
 }): JSX.Element => {
-  const [copied, setCopied] = useState(false);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const report = formatErrorReport(error, editorType);
 
   const handleCopy = async (): Promise<void> => {
-    try {
-      await navigator.clipboard.writeText(report);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      setCopied(false);
-    }
+    const ok = await copyTextToClipboard(report);
+    setCopyState(ok ? 'copied' : 'failed');
+    window.setTimeout(() => setCopyState('idle'), 2000);
   };
 
   return (
@@ -48,7 +76,11 @@ const ErrorDetails = ({
         {report}
       </pre>
       <Button secondary onClick={handleCopy} fullWidth>
-        {copied ? 'Copied!' : 'Copy error details'}
+        {copyState === 'copied'
+          ? 'Copied!'
+          : copyState === 'failed'
+            ? 'Copy failed — select the text above and copy manually'
+            : 'Copy error details'}
       </Button>
     </Stack>
   );

--- a/ui-src/context/useFigma.ts
+++ b/ui-src/context/useFigma.ts
@@ -1,11 +1,18 @@
 import { exportStream } from '@penpot/library';
+import * as Sentry from '@sentry/react';
 import { useEffect, useRef, useState } from 'preact/hooks';
 
 import { type MessageData, createInMemoryWritable, sendMessage } from '@ui/context';
 import { identify, track } from '@ui/metrics/mixpanel';
 import { parse } from '@ui/parser';
-import type { ExportScope, ExternalLibrary, Steps } from '@ui/types';
+import type { ErrorOrigin, ErrorPayload, ExportScope, ExternalLibrary, Steps } from '@ui/types';
 import { extractFileIdFromPenpotUrl, fileSizeInMB, formatExportTime } from '@ui/utils';
+
+const buildUiErrorPayload = (reason: unknown, origin: ErrorOrigin): ErrorPayload => ({
+  message: reason instanceof Error ? reason.message : String(reason),
+  stack: reason instanceof Error ? reason.stack : undefined,
+  origin
+});
 
 export type FormValues = {
   externalLibraries: ExternalLibrary[];
@@ -15,7 +22,7 @@ export type UseFigmaHook = {
   missingFonts: string[] | undefined;
   exporting: boolean;
   summary: boolean;
-  error: boolean;
+  error: ErrorPayload | null;
   step: Steps;
   stepLabel: string | undefined;
   stepName: string | undefined;
@@ -41,7 +48,7 @@ export const useFigma = (): UseFigmaHook => {
   const [missingFonts, setMissingFonts] = useState<string[]>();
   const [exporting, setExporting] = useState(false);
   const [summary, setSummary] = useState(false);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<ErrorPayload | null>(null);
   const [exportedBlob, setExportedBlob] = useState<{ blob: Blob; filename: string } | null>(null);
   const [exportTime, setExportTime] = useState<number | null>(null);
   const [exportScope, setExportScope] = useState<ExportScope>('all');
@@ -57,8 +64,37 @@ export const useFigma = (): UseFigmaHook => {
   const [processedItems, setProcessedItems] = useState(0);
   const [progressPercentage, setProgressPercentage] = useState(0);
 
+  const editorTypeRef = useRef(editorType);
+  editorTypeRef.current = editorType;
+
   const postMessage = (type: string, data?: unknown): void => {
     parent.postMessage({ pluginMessage: { type, data } }, '*');
+  };
+
+  const handleError = (payload: ErrorPayload): void => {
+    setError(payload);
+    setExporting(false);
+    track('Error', {
+      'Error Message': payload.message,
+      'Error Origin': payload.origin,
+      'Error Step': payload.step,
+      'Error Layer': payload.layer
+    });
+
+    if (payload.origin === 'plugin') {
+      const sentryError = new Error(payload.message);
+      if (payload.stack) sentryError.stack = payload.stack;
+      Sentry.captureException(sentryError, {
+        tags: {
+          errorOrigin: payload.origin,
+          errorStep: payload.step ?? 'unknown'
+        },
+        extra: {
+          layer: payload.layer,
+          editorType: editorTypeRef.current
+        }
+      });
+    }
   };
 
   const calculatePercentage = (item: number, total: number): number => {
@@ -92,7 +128,7 @@ export const useFigma = (): UseFigmaHook => {
         setMissingFonts(undefined);
         setExporting(false);
         setSummary(false);
-        setError(false);
+        setError(null);
         setExportedBlob(null);
         setExportTime(null);
         setExportScope('all');
@@ -190,11 +226,9 @@ export const useFigma = (): UseFigmaHook => {
         break;
       }
       case 'ERROR': {
-        setError(true);
-        setExporting(false);
-        track('Error', { 'Error Message': pluginMessage.data });
+        handleError(pluginMessage.data);
 
-        throw new Error(pluginMessage.data);
+        break;
       }
     }
   };
@@ -248,12 +282,24 @@ export const useFigma = (): UseFigmaHook => {
   };
 
   useEffect(() => {
+    const onWindowError = (event: ErrorEvent): void => {
+      handleError(buildUiErrorPayload(event.error ?? event.message, 'ui'));
+    };
+
+    const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
+      handleError(buildUiErrorPayload(event.reason, 'unhandled-rejection'));
+    };
+
     window.addEventListener('message', onMessage);
+    window.addEventListener('error', onWindowError);
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
 
     postMessage('ready');
 
     return (): void => {
       window.removeEventListener('message', onMessage);
+      window.removeEventListener('error', onWindowError);
+      window.removeEventListener('unhandledrejection', onUnhandledRejection);
     };
   }, []);
 

--- a/ui-src/main.tsx
+++ b/ui-src/main.tsx
@@ -1,8 +1,11 @@
 import '@create-figma-plugin/ui/css/base.css';
+import * as Sentry from '@sentry/react';
+import type { JSX } from 'preact';
 import { StrictMode } from 'preact/compat';
 import { createRoot } from 'react-dom/client';
 
 import { App } from '@ui/App';
+import { FatalErrorFallback } from '@ui/components/FatalErrorFallback';
 import { initializeMixpanel } from '@ui/metrics/mixpanel';
 import { initializeSentry } from '@ui/metrics/sentry';
 
@@ -14,6 +17,12 @@ initializeSentry();
 
 createRoot(document.getElementById('root') as HTMLElement).render(
   <StrictMode>
-    <App />
+    <Sentry.ErrorBoundary
+      fallback={({ error }): JSX.Element => (
+        <FatalErrorFallback error={error instanceof Error ? error : new Error(String(error))} />
+      )}
+    >
+      <App />
+    </Sentry.ErrorBoundary>
   </StrictMode>
 );

--- a/ui-src/types/errorPayload.ts
+++ b/ui-src/types/errorPayload.ts
@@ -1,0 +1,11 @@
+import type { Steps } from './progressMessages';
+
+export type ErrorOrigin = 'plugin' | 'ui' | 'unhandled-rejection';
+
+export type ErrorPayload = {
+  message: string;
+  stack?: string;
+  step?: Steps;
+  layer?: string;
+  origin: ErrorOrigin;
+};

--- a/ui-src/types/index.ts
+++ b/ui-src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './component';
+export * from './errorPayload';
 export * from './externalLibraries';
 export * from './penpotDocument';
 export * from './penpotNode';

--- a/ui-src/types/progressMessages.ts
+++ b/ui-src/types/progressMessages.ts
@@ -1,5 +1,7 @@
 import type { PenpotDocument } from '@ui/types';
 
+import type { ErrorPayload } from './errorPayload';
+
 export type ExportScope = 'all' | 'current';
 
 export type Steps =
@@ -58,7 +60,7 @@ export type ReloadMessage = {
 
 export type ErrorMessage = {
   type: 'ERROR';
-  data: string;
+  data: ErrorPayload;
 };
 
 export type UserDataMessage = {

--- a/ui-src/utils/formatErrorReport.ts
+++ b/ui-src/utils/formatErrorReport.ts
@@ -1,0 +1,48 @@
+import type { ErrorPayload } from '@ui/types';
+
+declare const APP_VERSION: string;
+
+const ISSUES_URL = 'https://github.com/penpot/penpot-exporter-figma-plugin/issues';
+
+export const formatErrorReport = (error: ErrorPayload, editorType: string): string => {
+  const lines = [`Plugin version: ${APP_VERSION}`, `File type: ${editorType}`];
+
+  if (error.step) lines.push(`Step: ${error.step}`);
+  if (error.layer) lines.push(`Layer: ${error.layer}`);
+
+  lines.push('', `Message: ${error.message}`);
+
+  if (error.stack) {
+    lines.push('', 'Stack:', error.stack);
+  }
+
+  return lines.join('\n');
+};
+
+export const buildErrorIssueUrl = (report: string): string => {
+  const title = encodeURIComponent('Export error');
+  const body = encodeURIComponent(
+    [
+      '## Error report',
+      '',
+      'Please describe what you were exporting (file contents, selection, etc.):',
+      '',
+      '',
+      '## Figma file (very helpful!)',
+      '',
+      'If possible, **attach the `.fig` file** (or a minimal reproduction) that triggered the error.',
+      'Drag-and-drop the file into this comment box to attach it.',
+      '',
+      "If the file is confidential, share it privately with the maintainers (mention you'd prefer that and we'll coordinate), or attach a stripped-down version that still reproduces the issue.",
+      '',
+      '## Technical details',
+      '',
+      '```',
+      report,
+      '```'
+    ].join('\n')
+  );
+  return `${ISSUES_URL}/new?title=${title}&body=${body}`;
+};
+
+export const ERROR_ISSUES_URL = ISSUES_URL;

--- a/ui-src/utils/index.ts
+++ b/ui-src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './fileSizeInMB';
+export * from './formatErrorReport';
 export * from './formatExportTime';
 export * from './validatePenpotUrl';


### PR DESCRIPTION
## What

The plugin used to freeze on the progress screen when the export pipeline threw (e.g. some SVG / vector nodes). The exception was swallowed by the Figma sandbox and the UI never recovered.

Now we surface it.

## Changes

- `handleExportMessage` catches and posts an `ERROR` message to the UI.
- Plugin tracks the active step / layer so the report says where it failed.
- UI listens to `window.error` and `unhandledrejection`, plus a `Sentry.ErrorBoundary` for React render crashes.
- New error screen shows the message + stack, a "Copy error details" button, and a GitHub issue link prefilled with the report and a request for the `.fig` file.
- Plugin-origin errors are reported to Sentry with `step` / `editorType` context.

## How to test

1. Run an export on a file that crashes the pipeline (an SVG-only `.fig` is one reliable repro).
2. The progress screen should be replaced by the error screen instead of hanging.
3. "Retry" and "Cancel" still work; "Copy error details" copies the report; the GitHub link opens a prefilled issue.