### PR TITLE
Fix plugin crash when exporting files with large or complex vectors.

### DIFF
--- a/.changeset/skip-oversized-vector-network.md
+++ b/.changeset/skip-oversized-vector-network.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Fix plugin crash when exporting files with large or complex vectors.

--- a/plugin-src/transformers/partials/transformStrokes.ts
+++ b/plugin-src/transformers/partials/transformStrokes.ts
@@ -46,10 +46,9 @@ export const transformStrokes = (
 export const transformStrokesFromVector = (
   node: VectorNode,
   vector: Command[],
-  vectorRegion: VectorRegion | undefined
+  vectorRegion: VectorRegion | undefined,
+  vectorNetwork: VectorNetwork | undefined
 ): Pick<ShapeAttributes, 'strokes'> => {
-  const vectorNetwork = safeGetVectorNetwork(node);
-
   const strokeCaps = (stroke: Stroke): Stroke => {
     if (vectorRegion !== undefined) return stroke;
     if (!vectorNetwork) return stroke;

--- a/plugin-src/transformers/partials/transformVectorPaths.ts
+++ b/plugin-src/transformers/partials/transformVectorPaths.ts
@@ -49,16 +49,18 @@ export const clearParsedCache = (): void => {
 };
 
 export const transformVectorPaths = (node: VectorNode): PathShape[] => {
-  let regions: readonly VectorRegion[] = [];
-
+  // Resolve vectorNetwork once; reading it per subpath crashes the plugin on
+  // large vectors via accumulated Figma WASM state.
+  let vectorNetwork: VectorNetwork | undefined;
   try {
-    regions = node.vectorNetwork?.regions ?? [];
+    vectorNetwork = node.vectorNetwork ?? undefined;
   } catch (error) {
     console.warn('Could not access the vector network', node.name, error);
   }
 
-  let vectorPaths: readonly VectorPath[] = [];
+  const regions: readonly VectorRegion[] = vectorNetwork ? (vectorNetwork.regions ?? []) : [];
 
+  let vectorPaths: readonly VectorPath[] = [];
   try {
     vectorPaths = node.vectorPaths ?? [];
   } catch (error) {
@@ -136,7 +138,7 @@ export const transformVectorPaths = (node: VectorNode): PathShape[] => {
       }
       // Deduplicate: skip if we've already seen a path with identical vertices (O(1) hash lookup)
       if (!seenVertexHashes.has(currentHash)) {
-        const pathShape = transformVectorPath(node, vectorPath, regions[i], count);
+        const pathShape = transformVectorPath(node, vectorPath, regions[i], count, vectorNetwork);
         if (pathShape) {
           seenVertexHashes.add(currentHash);
           includedVectorPathsData.push(vectorPath.data);
@@ -166,7 +168,7 @@ export const transformVectorPaths = (node: VectorNode): PathShape[] => {
   const geometryShapes: PathShape[] = [];
   if (shouldIncludeFillGeometry) {
     for (const geometry of validFillGeometry) {
-      const geometryShape = transformVectorPath(node, geometry, undefined, count);
+      const geometryShape = transformVectorPath(node, geometry, undefined, count, vectorNetwork);
       if (geometryShape) {
         geometryShapes.push(geometryShape);
         count++;
@@ -238,7 +240,8 @@ const transformVectorPath = (
   node: VectorNode,
   vectorPath: VectorPath,
   vectorRegion: VectorRegion | undefined,
-  index: number
+  index: number,
+  vectorNetwork: VectorNetwork | undefined
 ): PathShape | undefined => {
   const normalizedPaths = getParsedCommands(vectorPath.data);
   if (!normalizedPaths || normalizedPaths.length === 0) {
@@ -258,7 +261,7 @@ const transformVectorPath = (
     constraintsV: 'scale',
     ...transformVectorIds(node, index),
     ...transformVectorFills(node, vectorPath, vectorRegion),
-    ...transformStrokesFromVector(node, normalizedPaths, vectorRegion),
+    ...transformStrokesFromVector(node, normalizedPaths, vectorRegion, vectorNetwork),
     ...transformEffects(node),
     ...transformSceneNode(node),
     ...transformBlend(node),

--- a/tests/plugin-src/transformers/vectorGeometryRegression.test.ts
+++ b/tests/plugin-src/transformers/vectorGeometryRegression.test.ts
@@ -103,6 +103,27 @@ describe('vector geometry regression', () => {
     expect(result).toHaveLength(0);
   });
 
+  it('reads vectorNetwork only once per vector', () => {
+    const node = createVectorNode({
+      vectorPaths: [
+        { data: 'M 0 0 L 10 10 Z', windingRule: 'NONZERO' },
+        { data: 'M 20 20 L 30 30 Z', windingRule: 'NONZERO' }
+      ]
+    });
+
+    let readCount = 0;
+    Object.defineProperty(node, 'vectorNetwork', {
+      get: () => {
+        readCount++;
+        return { regions: [], vertices: [] };
+      }
+    });
+
+    transformVectorPaths(node);
+
+    expect(readCount).toBe(1);
+  });
+
   it('returns undefined for star/polygon nodes with invalid fillGeometry path data', () => {
     const node = createPathNode({
       fillGeometry: [{ data: 'M 0 0 L nan 10 Z', windingRule: 'NONZERO' }]


### PR DESCRIPTION
## Problem

  Exporting some Figma files crashed the plugin runtime with:

  in get_vectorNetwork: Aborted(). Build with -sASSERTIONS for more info.
  Plugin runtime aborted

  The abort happened on vectors with many subpaths (e.g. flattened text, complex SVG imports). Once tripped, the plugin sandbox dumped tens of
  thousands of "Object leaks" lines to the console and the export never finished.

  ## Root cause

  `transformStrokesFromVector` is invoked once per subpath inside `transformVectorPaths`, and each invocation called `safeGetVectorNetwork(node)` —
  i.e. read `node.vectorNetwork`. A vector with N subpaths therefore performed N reads of the same getter. The repeated reads accumulated state inside
  Figma's Emscripten/WASM runtime until an internal assertion failed (`get_vectorNetwork: Aborted()`). The abort is not a JavaScript exception, so the
  existing `try/catch` around `safeGetVectorNetwork` could not recover from it.

  ## Fix

  Resolve `node.vectorNetwork` **once** per vector at the top of `transformVectorPaths` and reuse the resolved value:

  - `transformVectorPaths` reads `node.vectorNetwork` exactly once, derives `regions` from it, and threads the resolved value into
  `transformVectorPath`.
  - `transformStrokesFromVector` now takes `vectorNetwork: VectorNetwork | undefined` as a required parameter instead of resolving it internally.

  This reduces vectorNetwork getter calls from `O(subpaths)` to `O(1)` per vector, which keeps Figma's WASM well below the assertion threshold even on
  pathologically large vectors.

  ## Verification

  - Reproduced the original crash on the failing file before the fix.
  - After the fix, the same file exports cleanly.
  - New unit test in `vectorGeometryRegression.test.ts` spies on the `vectorNetwork` getter and asserts it is read exactly once per vector, guarding
  against future regressions.
  - All existing tests pass (292 total).