### PR TITLE
fix: stream images individually to avoid OOM on large exports

### DIFF
--- a/.changeset/stream-images-oom.md
+++ b/.changeset/stream-images-oom.md
@@ -2,4 +2,4 @@
 'penpot-exporter': patch
 ---
 
-Stream images individually from the plugin to the UI to reduce peak memory on large exports, avoiding out-of-memory crashes on image-heavy files.
+Fix export crashing (out of memory) on large, image-heavy files.

--- a/.changeset/stream-images-oom.md
+++ b/.changeset/stream-images-oom.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Stream images individually from the plugin to the UI to reduce peak memory on large exports, avoiding out-of-memory crashes on image-heavy files.

--- a/plugin-src/processors/processAssets.ts
+++ b/plugin-src/processors/processAssets.ts
@@ -8,11 +8,7 @@ import type { TypographyStyle } from '@ui/lib/types/shapes/textShape';
 import type { FillStyle } from '@ui/lib/types/utils/fill';
 
 export const processAssets = async (): Promise<
-  [
-    Record<string, Uint8Array<ArrayBuffer>>,
-    Record<string, FillStyle>,
-    Record<string, TypographyStyle>
-  ]
+  [Record<string, FillStyle>, Record<string, TypographyStyle>]
 > => {
   const total = images.size + paintStyles.size + textStyles.size;
 
@@ -28,7 +24,9 @@ export const processAssets = async (): Promise<
 
   const processedPaintStyles = await processPaintStyles(1);
   const processedTextStyles = await processTextStyles(paintStyles.size + 1);
-  const processedImages = await processImages(paintStyles.size + textStyles.size + 1);
 
-  return [processedImages, processedPaintStyles, processedTextStyles];
+  // Streams each image to the UI as a PENPOT_IMAGE message; returns nothing.
+  await processImages(paintStyles.size + textStyles.size + 1);
+
+  return [processedPaintStyles, processedTextStyles];
 };

--- a/plugin-src/processors/processImages.ts
+++ b/plugin-src/processors/processImages.ts
@@ -3,14 +3,10 @@ import { yieldByTime } from '@common/sleep';
 import { images } from '@plugin/libraries';
 import { flushProgress, reportProgress } from '@plugin/utils';
 
-export const processImages = async (
-  currentAsset: number
-): Promise<Record<string, Uint8Array<ArrayBuffer>>> => {
-  // Images are streamed to the UI one by one (PENPOT_IMAGE messages) rather than
-  // returned in bulk, so the document built downstream carries an empty record.
-  const noImages: Record<string, Uint8Array<ArrayBuffer>> = {};
-
-  if (images.size === 0) return noImages;
+// Images are streamed to the UI one by one (PENPOT_IMAGE messages) instead of
+// being returned in bulk, so they never get accumulated plugin-side.
+export const processImages = async (currentAsset: number): Promise<void> => {
+  if (images.size === 0) return;
 
   let currentImage = currentAsset;
 
@@ -44,6 +40,4 @@ export const processImages = async (
   flushProgress();
 
   await yieldByTime(undefined, true);
-
-  return noImages;
 };

--- a/plugin-src/processors/processImages.ts
+++ b/plugin-src/processors/processImages.ts
@@ -6,9 +6,11 @@ import { flushProgress, reportProgress } from '@plugin/utils';
 export const processImages = async (
   currentAsset: number
 ): Promise<Record<string, Uint8Array<ArrayBuffer>>> => {
-  const processedImages: Record<string, Uint8Array<ArrayBuffer>> = {};
+  // Images are streamed to the UI one by one (PENPOT_IMAGE messages) rather than
+  // returned in bulk, so the document built downstream carries an empty record.
+  const noImages: Record<string, Uint8Array<ArrayBuffer>> = {};
 
-  if (images.size === 0) return processedImages;
+  if (images.size === 0) return noImages;
 
   let currentImage = currentAsset;
 
@@ -17,7 +19,12 @@ export const processImages = async (
       const bytes = await image?.getBytesAsync();
 
       if (bytes) {
-        processedImages[key] = bytes as Uint8Array<ArrayBuffer>;
+        // Stream each image to the UI immediately instead of accumulating its
+        // bytes in memory, keeping the plugin-side peak at ~1 image at a time.
+        reportProgress({
+          type: 'PENPOT_IMAGE',
+          data: { key, bytes: bytes as Uint8Array<ArrayBuffer> }
+        });
       }
     } catch {
       // Skip images without valid data (e.g., empty image fills)
@@ -38,5 +45,5 @@ export const processImages = async (
 
   await yieldByTime(undefined, true);
 
-  return processedImages;
+  return noImages;
 };

--- a/plugin-src/transformers/buildPenpotDocument.ts
+++ b/plugin-src/transformers/buildPenpotDocument.ts
@@ -16,12 +16,11 @@ export const buildPenpotDocument = async (
   name: string,
   children: PenpotPage[]
 ): Promise<PenpotDocument> => {
-  const [images, paintStyles, textStyles] = await processAssets();
+  const [paintStyles, textStyles] = await processAssets();
 
   return {
     name,
     children,
-    images,
     paintStyles,
     textStyles,
     tokens: undefined,

--- a/plugin-src/transformers/transformDocumentNode.ts
+++ b/plugin-src/transformers/transformDocumentNode.ts
@@ -27,12 +27,11 @@ export const transformDocumentNode = async (
   await registerTextStyles();
 
   const children = await processPages(node, scope);
-  const [images, paintStyles, textStyles] = await processAssets();
+  const [paintStyles, textStyles] = await processAssets();
 
   return {
     name: node.name,
     children,
-    images,
     paintStyles,
     textStyles,
     tokens,

--- a/tests/plugin-src/processors/processImages.test.ts
+++ b/tests/plugin-src/processors/processImages.test.ts
@@ -33,13 +33,12 @@ describe('processImages', () => {
     images.clear();
   });
 
-  it('streams one PENPOT_IMAGE per image, empties the map and returns an empty record', async () => {
+  it('streams one PENPOT_IMAGE per image and empties the map', async () => {
     images.set('hashA', createImage(new Uint8Array([1, 2, 3])));
     images.set('hashB', createImage(new Uint8Array([4, 5, 6])));
 
-    const result = await processImages(1);
+    await processImages(1);
 
-    expect(result).toEqual({});
     expect(images.size).toBe(0);
     expect(postedImageMessages()).toEqual([
       { type: 'PENPOT_IMAGE', data: { key: 'hashA', bytes: new Uint8Array([1, 2, 3]) } },
@@ -53,9 +52,8 @@ describe('processImages', () => {
     } as unknown as Image);
     images.set('ok', createImage(new Uint8Array([7, 8])));
 
-    const result = await processImages(1);
+    await processImages(1);
 
-    expect(result).toEqual({});
     expect(images.size).toBe(0);
     expect(postedImageMessages()).toEqual([
       { type: 'PENPOT_IMAGE', data: { key: 'ok', bytes: new Uint8Array([7, 8]) } }
@@ -63,9 +61,8 @@ describe('processImages', () => {
   });
 
   it('does nothing when there are no images', async () => {
-    const result = await processImages(1);
+    await processImages(1);
 
-    expect(result).toEqual({});
     expect(postedImageMessages()).toHaveLength(0);
   });
 });

--- a/tests/plugin-src/processors/processImages.test.ts
+++ b/tests/plugin-src/processors/processImages.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { images as ImagesMap } from '@plugin/libraries';
+import type { processImages as ProcessImagesFn } from '@plugin/processors/processImages';
+
+const mockPostMessage = vi.fn();
+
+(globalThis as { figma?: typeof figma }).figma = {
+  ui: { postMessage: mockPostMessage }
+} as unknown as typeof figma;
+
+const createImage = (bytes: Uint8Array): Image =>
+  ({ getBytesAsync: vi.fn().mockResolvedValue(bytes) }) as unknown as Image;
+
+const postedImageMessages = (): unknown[] =>
+  mockPostMessage.mock.calls
+    .map(([message]) => message)
+    .filter(message => message.type === 'PENPOT_IMAGE');
+
+describe('processImages', () => {
+  let processImages: typeof ProcessImagesFn;
+  let images: typeof ImagesMap;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mockPostMessage.mockClear();
+
+    // Import both from the same fresh module graph so processImages mutates the
+    // very same `images` map instance we seed here.
+    images = (await import('@plugin/libraries')).images;
+    processImages = (await import('@plugin/processors/processImages')).processImages;
+
+    images.clear();
+  });
+
+  it('streams one PENPOT_IMAGE per image, empties the map and returns an empty record', async () => {
+    images.set('hashA', createImage(new Uint8Array([1, 2, 3])));
+    images.set('hashB', createImage(new Uint8Array([4, 5, 6])));
+
+    const result = await processImages(1);
+
+    expect(result).toEqual({});
+    expect(images.size).toBe(0);
+    expect(postedImageMessages()).toEqual([
+      { type: 'PENPOT_IMAGE', data: { key: 'hashA', bytes: new Uint8Array([1, 2, 3]) } },
+      { type: 'PENPOT_IMAGE', data: { key: 'hashB', bytes: new Uint8Array([4, 5, 6]) } }
+    ]);
+  });
+
+  it('skips images whose bytes cannot be read without throwing', async () => {
+    images.set('broken', {
+      getBytesAsync: vi.fn().mockRejectedValue(new Error('no data'))
+    } as unknown as Image);
+    images.set('ok', createImage(new Uint8Array([7, 8])));
+
+    const result = await processImages(1);
+
+    expect(result).toEqual({});
+    expect(images.size).toBe(0);
+    expect(postedImageMessages()).toEqual([
+      { type: 'PENPOT_IMAGE', data: { key: 'ok', bytes: new Uint8Array([7, 8]) } }
+    ]);
+  });
+
+  it('does nothing when there are no images', async () => {
+    const result = await processImages(1);
+
+    expect(result).toEqual({});
+    expect(postedImageMessages()).toHaveLength(0);
+  });
+});

--- a/ui-src/context/useFigma.ts
+++ b/ui-src/context/useFigma.ts
@@ -55,6 +55,7 @@ export const useFigma = (): UseFigmaHook => {
   const [exportLibraries, setExportLibraries] = useState<string[]>([]);
   const [editorType, setEditorType] = useState<UseFigmaHook['editorType']>('figma');
   const exportStartTimeRef = useRef<number | null>(null);
+  const collectedImagesRef = useRef<Record<string, Uint8Array<ArrayBuffer>>>({});
 
   const [step, setStep] = useState<Steps>('processing');
   const [stepLabel, setStepLabel] = useState<string | undefined>(undefined);
@@ -137,8 +138,14 @@ export const useFigma = (): UseFigmaHook => {
 
         totalItemsRef.current = 0;
         exportStartTimeRef.current = null;
+        collectedImagesRef.current = {};
 
         track('Plugin Reloaded');
+
+        break;
+      }
+      case 'PENPOT_IMAGE': {
+        collectedImagesRef.current[pluginMessage.data.key] = pluginMessage.data.bytes;
 
         break;
       }
@@ -146,6 +153,11 @@ export const useFigma = (): UseFigmaHook => {
         if (pluginMessage.data.missingFonts) {
           setMissingFonts(pluginMessage.data.missingFonts);
         }
+
+        // Images arrive streamed as PENPOT_IMAGE messages before this document;
+        // attach the collected bytes so the parser sees the full asset record.
+        pluginMessage.data.images = collectedImagesRef.current;
+        collectedImagesRef.current = {};
 
         const context = await parse(pluginMessage.data);
 
@@ -226,6 +238,7 @@ export const useFigma = (): UseFigmaHook => {
         break;
       }
       case 'ERROR': {
+        collectedImagesRef.current = {};
         handleError(pluginMessage.data);
 
         break;
@@ -268,6 +281,7 @@ export const useFigma = (): UseFigmaHook => {
   const exportPenpot = (data: FormValues): void => {
     setExporting(true);
     exportStartTimeRef.current = Date.now();
+    collectedImagesRef.current = {};
 
     track('File Export Started', { scope: exportScope });
 

--- a/ui-src/parser/builders/buildAssets.ts
+++ b/ui-src/parser/builders/buildAssets.ts
@@ -13,7 +13,7 @@ export const buildAssets = async (
   context: PenpotContext,
   document: PenpotDocument
 ): Promise<void> => {
-  const { images, paintStyles, textStyles } = document;
+  const { images = {}, paintStyles, textStyles } = document;
 
   const imagesToOptimize = Object.entries(images);
   const paintStylesToRegister = Object.entries(paintStyles);

--- a/ui-src/types/penpotDocument.ts
+++ b/ui-src/types/penpotDocument.ts
@@ -8,7 +8,8 @@ export type PenpotDocument = {
   name: string;
   children?: PenpotPage[];
   components: Record<string, ComponentRoot>;
-  images: Record<string, Uint8Array<ArrayBuffer>>;
+  // Streamed separately as PENPOT_IMAGE messages and attached by the UI before parsing.
+  images?: Record<string, Uint8Array<ArrayBuffer>>;
   paintStyles: Record<string, FillStyle>;
   textStyles: Record<string, TypographyStyle>;
   tokens?: Tokens;

--- a/ui-src/types/progressMessages.ts
+++ b/ui-src/types/progressMessages.ts
@@ -26,6 +26,14 @@ export type PenpotDocumentMessage = {
   data: PenpotDocument;
 };
 
+export type PenpotImageMessage = {
+  type: 'PENPOT_IMAGE';
+  data: {
+    key: string;
+    bytes: Uint8Array<ArrayBuffer>;
+  };
+};
+
 export type ProgressStepMessage = {
   type: 'PROGRESS_STEP';
   data: {
@@ -82,6 +90,7 @@ export type EditorTypeMessage = {
 
 export type PluginMessage =
   | PenpotDocumentMessage
+  | PenpotImageMessage
   | ProgressStepMessage
   | ProgressProcessedItemsMessage
   | ProgressCurrentItemMessage


### PR DESCRIPTION
## What

Stream images from the plugin to the UI **one by one** instead of bundling every image's bytes into the single `PENPOT_DOCUMENT` message.

A new `PENPOT_IMAGE` message (`{ key, bytes }`) is emitted per image during `processImages`. The UI accumulates them in a ref and attaches them to the document when `PENPOT_DOCUMENT` arrives, so the rest of the pipeline is untouched.

## Why

Large, image-heavy files (>200 MB) were OOM-crashing on export. Two memory cliffs compounded:

1. **The monolithic structured clone.** `figma.ui.postMessage(document)` clones the entire payload (tree + styles + **all image bytes**) in one shot. During that clone the source heap and the serialized copy coexist → a momentary ~2× peak of everything.
2. **Plugin-side accumulation.** `processImages` collected every image's bytes into one record before sending, so the plugin held "all images at once".

Streaming removes the image bytes from the giant clone (now many small per-image clones) and drops the plugin-side peak from *"tree + all images"* to *"tree + 1 image"*.

## How

- **`progressMessages.ts`** — new `PenpotImageMessage` added to the `PluginMessage` union. Deliberately **not** added to `BUFFERED_PROGRESS_TYPES`: the buffer keys by message type, so buffering it would keep only the last image and drop the rest.
- **`processImages.ts`** — now returns `void` and just streams one `PENPOT_IMAGE` per image. The existing per-iteration `images.delete(key)` already frees the sandbox.
- **The old bulk path is removed**, not bypassed: `processAssets` no longer returns images (2-tuple now), and `transformDocumentNode` / `buildPenpotDocument` no longer put `images` on the document. `PenpotDocument.images` is therefore optional — the plugin no longer provides it; the UI does, from the stream.
- **`useFigma.ts`** — `collectedImagesRef` accumulates incoming images; attached to `data.images` on `PENPOT_DOCUMENT`, then reset. Cleared on `RELOAD`, `ERROR`, and at the start of `exportPenpot()` (retries).

### Correctness

- Same `{ key → bytes }` pairs reach `parse` / `buildAssets` with the same shape — only the transport changed, not the data. `buildAssets` defaults `images` to `{}` for the (never-hit at parse time) optional case.
- **Ordering is guaranteed:** the message buffer flushes pending messages before any non-buffered message (covered by `messageBuffer.test.ts`). All `PENPOT_IMAGE` messages are sent during processing and `PENPOT_DOCUMENT` last; the UI's `PENPOT_IMAGE` handler is synchronous, so the ref is fully populated before the async document handler runs.
- FigJam and Slides are covered automatically (both funnel through `buildPenpotDocument`).

## Scope / trade-offs

- This reduces the **plugin-side peak** and removes the **giant clone** — the two worst cliffs. It does **not** reduce the UI-side peak: the UI still holds all bytes in the ref, same as today's `document.images`. UI-side streaming is a separate, larger change.
- Each `PENPOT_IMAGE` (non-buffered) flushes pending progress, so progress now updates per-image instead of throttled at 500 ms — more tiny `postMessage`s, negligible cost. Easy to throttle later if ever needed.

## Testing

- New `tests/plugin-src/processors/processImages.test.ts`: one `PENPOT_IMAGE` per image, map emptied, failed `getBytesAsync` skipped silently.
- Full suite green (310 tests), `tsc` (plugin + ui), ESLint and Prettier clean.
- Manual: exported a small image-bearing file (opens in Penpot with images intact) and a large file that previously OOM'd (now completes).
