### PR TITLE
fix: buffer the export zip as Blobs to cut heap usage

### DIFF
--- a/.changeset/zip-blobs-heap.md
+++ b/.changeset/zip-blobs-heap.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Reduce memory usage during export by buffering the output zip as Blobs instead of keeping it on the JS heap.

--- a/tests/ui-src/context/createInMemoryWritable.test.ts
+++ b/tests/ui-src/context/createInMemoryWritable.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { createInMemoryWritable } from '@ui/context/createInMemoryWritable';
+
+const writeChunks = async (
+  writable: WritableStream,
+  chunks: Uint8Array<ArrayBuffer>[]
+): Promise<void> => {
+  const writer = writable.getWriter();
+
+  for (const chunk of chunks) {
+    await writer.write(chunk);
+  }
+
+  await writer.close();
+};
+
+describe('createInMemoryWritable', () => {
+  it('produces a blob whose bytes match the concatenation of written chunks, in order', async () => {
+    const { writable, getBlob } = createInMemoryWritable();
+
+    const chunks = [
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array([4, 5]),
+      new Uint8Array([6, 7, 8, 9])
+    ];
+
+    await writeChunks(writable, chunks);
+
+    const bytes = new Uint8Array(await getBlob().arrayBuffer());
+
+    expect(Array.from(bytes)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('defaults the blob type to application/zip', async () => {
+    const { writable, getBlob } = createInMemoryWritable();
+
+    await writeChunks(writable, [new Uint8Array([0])]);
+
+    expect(getBlob().type).toBe('application/zip');
+  });
+
+  it('honours a custom blob type', async () => {
+    const { writable, getBlob } = createInMemoryWritable();
+
+    await writeChunks(writable, [new Uint8Array([0])]);
+
+    expect(getBlob('image/png').type).toBe('image/png');
+  });
+
+  it('produces an empty blob when nothing is written', () => {
+    const { getBlob } = createInMemoryWritable();
+
+    expect(getBlob().size).toBe(0);
+  });
+});

--- a/ui-src/context/createInMemoryWritable.ts
+++ b/ui-src/context/createInMemoryWritable.ts
@@ -2,11 +2,14 @@ export const createInMemoryWritable = (): {
   writable: WritableStream;
   getBlob: (type?: string) => Blob;
 } => {
-  const chunks: Uint8Array<ArrayBuffer>[] = [];
+  const chunks: Blob[] = [];
 
   const writable = new WritableStream({
     write(chunk: Uint8Array<ArrayBuffer>): void {
-      chunks.push(chunk);
+      // Wrap each chunk in a Blob: Chromium stores Blob payloads off the JS heap
+      // (paging to disk under memory pressure), and the Blob constructor snapshots
+      // the bytes so the original Uint8Array/ArrayBuffer becomes GC-able immediately.
+      chunks.push(new Blob([chunk]));
     },
     close(): void {},
     abort(err: Error): void {


### PR DESCRIPTION
## What

Buffer the exported `.penpot` zip as `Blob[]` instead of `Uint8Array[]` inside `createInMemoryWritable`. The public interface (`writable`, `getBlob`) is unchanged.

```diff
-  const chunks: Uint8Array<ArrayBuffer>[] = [];
+  const chunks: Blob[] = [];

     write(chunk: Uint8Array<ArrayBuffer>): void {
-      chunks.push(chunk);
+      chunks.push(new Blob([chunk]));
     },
```

## Why

Another memory peak during export, following on from the streaming work in #390.

`exportStream` (from `@penpot/library`) writes the zip to an in-memory `WritableStream` in chunks. We kept every chunk as a `Uint8Array` in a `Uint8Array[]` and only assembled the final `Blob` at the end — so the **entire zip sits on the JS heap for the whole duration of `exportStream`**, on top of everything else. On large, image-heavy files that's a ~1× zip-size cliff right at the export peak.

Two relevant `Blob` properties in Chromium (Figma is Chromium-only):

1. **Payload lives off the JS heap.** Chromium stores `Blob` bytes outside V8 and pages them to disk under memory pressure — the closest thing to "stream to disk" available here, since the File System Access API is not exposed inside Figma's sandboxed iframe.
2. **`new Blob([chunk])` snapshots the bytes on construction.** The original `Uint8Array` (and its `ArrayBuffer`) is no longer referenced after the `push`, so GC can reclaim it immediately instead of it surviving in the array until the end.

`new Blob(blobs, { type })` then composes the blobs **by reference** — no recopy — so `getBlob()` stays cheap.

## How

- **`createInMemoryWritable.ts`** — `chunks` is now `Blob[]`; `write()` pushes `new Blob([chunk])`; `getBlob` is unchanged (`new Blob(chunks, { type })` accepts a `Blob[]`).
- The only consumer (`useFigma.ts:172-186`) is untouched — same `Blob` comes out of `getBlob()`.
- No chunk coalescing in this PR. The optional `~8 MB` buffering before wrapping in a `Blob` is left as a follow-up, to do only if heap snapshots show overhead from many tiny `Blob`s.

## Scope / trade-offs

- **Memory only** — not perf, not output size. Output is binary-identical; no protocol or interface change.
- Reduces the **export-phase peak** (the final zip). It does **not** touch the plugin-side peak or the serialized document tree — those are separate follow-ups.
- Trade-off: many small `Blob`s carry minor bookkeeping overhead in Chromium. Coalescing is the escape hatch if it ever matters.

## Testing

- New `tests/ui-src/context/createInMemoryWritable.test.ts` (first UI-side test): bytes match the concatenation of written chunks in order, default + custom MIME type, empty blob.
- Full suite green (**314 tests**), `tsc` (plugin + ui), ESLint and Prettier clean.
- **Manual output-equivalence** — exported the same Figma file before and after the change and compared the unzipped trees. Note that two separate exports can't be byte-identical: `@penpot/library` regenerates the root file UUID per export, so all filenames and embedded ids differ by design. Verified instead:
  - identical `.penpot` size, total file count (14372), webp count (23), json count (14349);
  - **media (webp) is byte-for-byte identical** — same `sha256` multiset, same total bytes (1,622,662) — i.e. the one thing a buffering bug could actually corrupt (truncation / chunk reorder / dropped bytes) is intact;
  - top-level file JSON and object JSON identical after UUID normalization.
  - Residual JSON differences are entirely the per-export UUID regeneration, which happens upstream of this buffer.
