### PR TITLE
perf: fetch image bytes with a bounded concurrency pool

### DIFF
--- a/.changeset/getbytesasync-pool.md
+++ b/.changeset/getbytesasync-pool.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Speed up exports of image-heavy files by fetching image bytes from Figma with a small concurrency pool instead of one at a time.

--- a/common/asyncPool.ts
+++ b/common/asyncPool.ts
@@ -1,0 +1,20 @@
+// Runs `worker` over every item with at most `concurrency` workers in flight at
+// once. Workers share a single iterator, so each one pulls the next item as soon
+// as it finishes the previous one. Resolves when every item has been processed.
+export const asyncPool = async <T>(
+  concurrency: number,
+  items: Iterable<T>,
+  worker: (item: T) => Promise<void>
+): Promise<void> => {
+  const iterator = items[Symbol.iterator]();
+
+  const drain = async (): Promise<void> => {
+    for (let next = iterator.next(); !next.done; next = iterator.next()) {
+      await worker(next.value);
+    }
+  };
+
+  const workers = Array.from({ length: Math.max(1, concurrency) }, drain);
+
+  await Promise.all(workers);
+};

--- a/plugin-src/processors/processImages.ts
+++ b/plugin-src/processors/processImages.ts
@@ -1,7 +1,13 @@
+import { asyncPool } from '@common/asyncPool';
 import { yieldByTime } from '@common/sleep';
 
 import { images } from '@plugin/libraries';
 import { flushProgress, reportProgress } from '@plugin/utils';
+
+// `getBytesAsync` is a round-trip to the Figma host, so fetching images is
+// latency-bound. A small pool keeps a few requests in flight at once instead of
+// waiting for each one sequentially.
+const POOL_SIZE = 3;
 
 // Images are streamed to the UI one by one (PENPOT_IMAGE messages) instead of
 // being returned in bulk, so they never get accumulated plugin-side.
@@ -10,13 +16,13 @@ export const processImages = async (currentAsset: number): Promise<void> => {
 
   let currentImage = currentAsset;
 
-  for (const [key, image] of images.entries()) {
+  await asyncPool(POOL_SIZE, images, async ([key, image]) => {
     try {
       const bytes = await image?.getBytesAsync();
 
       if (bytes) {
         // Stream each image to the UI immediately instead of accumulating its
-        // bytes in memory, keeping the plugin-side peak at ~1 image at a time.
+        // bytes in memory, keeping the plugin-side peak at ~POOL_SIZE images.
         reportProgress({
           type: 'PENPOT_IMAGE',
           data: { key, bytes: bytes as Uint8Array<ArrayBuffer> }
@@ -35,7 +41,7 @@ export const processImages = async (currentAsset: number): Promise<void> => {
     });
 
     await yieldByTime();
-  }
+  });
 
   flushProgress();
 

--- a/tests/common/asyncPool.test.ts
+++ b/tests/common/asyncPool.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { asyncPool } from '@common/asyncPool';
+
+describe('asyncPool', () => {
+  it('runs the worker for every item', async () => {
+    const processed: number[] = [];
+
+    await asyncPool(2, [1, 2, 3, 4, 5], async item => {
+      processed.push(item);
+    });
+
+    expect(processed.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('never runs more than `concurrency` workers at once', async () => {
+    let active = 0;
+    let maxActive = 0;
+
+    await asyncPool(2, [1, 2, 3, 4, 5, 6], async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      // Yield twice so the other pool slots get a chance to start before we finish.
+      await Promise.resolve();
+      await Promise.resolve();
+      active--;
+    });
+
+    expect(maxActive).toBe(2);
+  });
+
+  it('processes all items even when concurrency exceeds the item count', async () => {
+    const processed: number[] = [];
+
+    await asyncPool(10, [1, 2, 3], async item => {
+      processed.push(item);
+    });
+
+    expect(processed.sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it('does nothing for an empty iterable', async () => {
+    let calls = 0;
+
+    await asyncPool(3, [], async () => {
+      calls++;
+    });
+
+    expect(calls).toBe(0);
+  });
+});

--- a/tests/plugin-src/processors/processImages.test.ts
+++ b/tests/plugin-src/processors/processImages.test.ts
@@ -65,4 +65,39 @@ describe('processImages', () => {
 
     expect(postedImageMessages()).toHaveLength(0);
   });
+
+  it('fetches image bytes concurrently instead of one at a time', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const release: Array<() => void> = [];
+
+    const gatedImage = (bytes: Uint8Array): Image =>
+      ({
+        getBytesAsync: vi.fn().mockImplementation(() => {
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+
+          return new Promise<Uint8Array>(resolve => {
+            release.push(() => {
+              inFlight--;
+              resolve(bytes);
+            });
+          });
+        })
+      }) as unknown as Image;
+
+    images.set('a', gatedImage(new Uint8Array([1])));
+    images.set('b', gatedImage(new Uint8Array([2])));
+    images.set('c', gatedImage(new Uint8Array([3])));
+
+    const done = processImages(1);
+
+    expect(maxInFlight).toBeGreaterThan(1);
+
+    release.forEach(resolve => resolve());
+    await done;
+
+    expect(images.size).toBe(0);
+    expect(postedImageMessages()).toHaveLength(3);
+  });
 });


### PR DESCRIPTION
## What

Fetch image bytes from Figma with a small **bounded concurrency pool** instead of one image at a time.

A new generic helper `common/asyncPool.ts` runs a worker over an iterable with at most N workers in flight (shared iterator, each worker pulls the next item as it finishes). `processImages` now drives `getBytesAsync` through it with `POOL_SIZE = 3`.

## Why

`image.getBytesAsync()` is a round-trip to the Figma host, so the image-fetch phase is **latency-bound, not CPU-bound** — most of the time was spent waiting for one request to come back before starting the next. On image-heavy files this phase dominated export time.

Running a few requests in flight overlaps those waits instead of summing them, cutting the fetch phase roughly proportionally to the pool size.

This builds directly on #390 (per-image streaming): because each image is streamed to the UI and deleted from the map the moment it's fetched, concurrency does **not** reintroduce accumulation — the plugin-side peak goes from ~1 image to at most ~`POOL_SIZE` images, which is negligible.

## How

- **`common/asyncPool.ts`** (new, ~20 lines) — `asyncPool(concurrency, items, worker)`. `concurrency` runners share one iterator via `items[Symbol.iterator]()`; each runner loops `iterator.next()` → `await worker(value)` until the iterator is exhausted. `Math.max(1, concurrency)` guards against a non-positive size. Resolves when all items are processed.
- **`processImages.ts`** — the sequential `for…of` loop is replaced by `asyncPool(POOL_SIZE, images, async ([key, image]) => { … })`. The per-image body is unchanged: stream `PENPOT_IMAGE`, `images.delete(key)`, bump `PROGRESS_PROCESSED_ITEMS`, `yieldByTime()`. Deleting the just-visited key from the `Map` during iteration is safe.

### Correctness / trade-offs

- **Read-only API** — `getBytesAsync` only reads from the host, so issuing several in parallel is safe.
- **Streaming order is now completion order, not insertion order.** This is functionally irrelevant: every `PENPOT_IMAGE` carries its `key` (image hash), so the UI keys them correctly regardless of arrival order.
- **Memory** — at most `POOL_SIZE` images are in flight at once (vs ~1 before). With #390 already in place nothing accumulates, so the extra peak is ~2 images.
- **Why 3?** A conservative default, not a benchmarked optimum: 1→3 captures most of the win on a latency-bound phase while keeping the memory peak and host pressure trivial; gains flatten beyond that and we have no data on how the Figma bridge throttles internally. It's a one-line constant — easy to retune once size/throughput telemetry (plan item S2) gives real numbers.

## Testing

- **`tests/common/asyncPool.test.ts`** (new) — runs the worker for every item; **never more than `concurrency` in flight**; completes when concurrency exceeds the item count; no-ops on an empty iterable.
- **`tests/plugin-src/processors/processImages.test.ts`** — new test gates each `getBytesAsync` behind a manual release and asserts more than one fetch is in flight at once. This test **fails on the old sequential code** (`expected 1 to be greater than 1`) and passes with the pool. The existing behaviour tests (one `PENPOT_IMAGE` per image, map emptied, broken image skipped) are unchanged and still green.
- Full suite green (**315 tests**), `tsc` (plugin + ui), ESLint and Prettier clean.
