### PR TITLE
perf: free decoded image pixels deterministically via createImageBitmap

### DIFF
--- a/.changeset/image-bitmap-pixel-release.md
+++ b/.changeset/image-bitmap-pixel-release.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Lower peak memory during export by decoding images with createImageBitmap and releasing the decoded pixels deterministically once each image is re-encoded.

--- a/tests/ui-src/parser/builders/optimizeFileMedias.test.ts
+++ b/tests/ui-src/parser/builders/optimizeFileMedias.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PenpotContext } from '@ui/lib/types/penpotContext';
+import { optimizeFileMedias } from '@ui/parser/builders/optimizeFileMedias';
+
+vi.mock('@ui/context', () => ({
+  sendMessage: vi.fn(),
+  flushMessageQueue: vi.fn()
+}));
+
+vi.mock('@ui/parser', () => ({
+  images: new Map()
+}));
+
+// optimizeImage relies on browser-only APIs (createImageBitmap, OffscreenCanvas)
+// that don't exist in the node test env, so we stub them. These tests cover the
+// pixel-release contract (the decoded bitmap is always closed), NOT the real
+// decode/encode — that is verified manually.
+type CanvasStubs = {
+  createImageBitmap?: typeof createImageBitmap;
+  OffscreenCanvas?: typeof OffscreenCanvas;
+};
+
+const closeSpy = vi.fn();
+let convertToBlob: () => Promise<Blob>;
+
+// A regular class so it can be invoked with `new` (arrow functions can't).
+class OffscreenCanvasStub {
+  getContext(): { drawImage: () => void } {
+    return { drawImage: (): void => {} };
+  }
+
+  convertToBlob(): Promise<Blob> {
+    return convertToBlob();
+  }
+}
+
+const setupCanvasStubs = (): void => {
+  closeSpy.mockClear();
+
+  (globalThis as CanvasStubs).createImageBitmap = vi.fn().mockResolvedValue({
+    width: 10,
+    height: 20,
+    close: closeSpy
+  }) as unknown as typeof createImageBitmap;
+
+  (globalThis as CanvasStubs).OffscreenCanvas =
+    OffscreenCanvasStub as unknown as typeof OffscreenCanvas;
+};
+
+const fakeContext = {
+  addFileMedia: vi.fn().mockReturnValue('uuid-1')
+} as unknown as PenpotContext;
+
+describe('optimizeFileMedias — decoded pixel release', () => {
+  beforeEach(() => {
+    setupCanvasStubs();
+    convertToBlob = (): Promise<Blob> => Promise.resolve(new Blob(['webp']));
+  });
+
+  it('closes the decoded bitmap after encoding to free its pixels', async () => {
+    await optimizeFileMedias(fakeContext, [['hash', new Uint8Array([1, 2, 3])]], 1);
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the bitmap even when encoding fails', async () => {
+    convertToBlob = (): Promise<Blob> => Promise.reject(new Error('encode failed'));
+
+    await expect(
+      optimizeFileMedias(fakeContext, [['hash', new Uint8Array([1, 2, 3])]], 1)
+    ).rejects.toThrow();
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui-src/parser/builders/optimizeFileMedias.ts
+++ b/ui-src/parser/builders/optimizeFileMedias.ts
@@ -57,33 +57,29 @@ async function optimizeImage(bytes: Uint8Array<ArrayBuffer>): Promise<{
   width: number;
   height: number;
 }> {
-  const url = URL.createObjectURL(new Blob([bytes]));
+  // createImageBitmap decodes straight from the bytes (no object URL / <img>
+  // intermediaries), and bitmap.close() lets us free the decoded pixels
+  // deterministically instead of waiting for the GC to collect a detached image.
+  const bitmap = await createImageBitmap(new Blob([bytes]));
 
   try {
-    const image = await new Promise<HTMLImageElement>((resolve, reject) => {
-      const img = new Image();
-      img.onload = (): void => resolve(img);
-      img.onerror = (): void => reject();
-      img.src = url;
-    });
-
-    const canvas = new OffscreenCanvas(image.width, image.height);
+    const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
     const context = canvas.getContext('2d');
 
     if (!context) {
       throw new Error('Could not create canvas context');
     }
 
-    context.drawImage(image, 0, 0);
+    context.drawImage(bitmap, 0, 0);
 
     const blob = await canvas.convertToBlob({ type: IMAGE_FORMAT, quality: IMAGE_QUALITY });
 
     return {
       blob,
-      width: image.width,
-      height: image.height
+      width: bitmap.width,
+      height: bitmap.height
     };
   } finally {
-    URL.revokeObjectURL(url);
+    bitmap.close();
   }
 }


### PR DESCRIPTION
## What

Decode images with `createImageBitmap` instead of an object URL + `HTMLImageElement`, and release the decoded pixels deterministically with `bitmap.close()` once each image has been re-encoded.

```diff
- const url = URL.createObjectURL(new Blob([bytes]));
- const image = await new Promise<HTMLImageElement>((resolve, reject) => {
-   const img = new Image();
-   img.onload = () => resolve(img);
-   img.onerror = () => reject();
-   img.src = url;
- });
- // …drawImage(image)…
- finally { URL.revokeObjectURL(url); }
+ const bitmap = await createImageBitmap(new Blob([bytes]));
+ // …drawImage(bitmap)…
+ finally { bitmap.close(); }
```

## Why

To re-encode an image to WebP we have to decode it first, and a **decoded** image is large regardless of its compressed size — a 4000×4000 image is ~64 MB of RGBA in memory.

With the old `<img>` path, that decoded buffer lived inside a detached `HTMLImageElement` and was only freed **whenever the GC got around to it**. Across many images in a row those buffers could pile up and inflate the export's memory peak.

`createImageBitmap` + `bitmap.close()` lets us free that buffer **immediately** after each image is encoded, so the decoded-pixel transient stays bounded to ~1 image at a time. It also drops the object-URL / `<img>` intermediaries — the bytes are decoded directly.

## How

- **`optimizeFileMedias.ts`** — `optimizeImage` now does `const bitmap = await createImageBitmap(new Blob([bytes]))`, draws the bitmap onto the `OffscreenCanvas`, and calls `bitmap.close()` in a `finally` so the pixels are released even if `convertToBlob` throws. The encode (WebP, quality 0.8) and the returned `{ blob, width, height }` are unchanged.

## Testing

- **`tests/ui-src/parser/builders/optimizeFileMedias.test.ts`** (new) — a **contract** test: the decoded bitmap is always closed, including when encoding fails (guards the `finally` against pixel leaks). `createImageBitmap` / `OffscreenCanvas` are stubbed because they don't exist in the node test env, so this covers the release contract, **not** the real decode/encode.
- Full suite green (**321 tests**), `tsc` (plugin + ui), ESLint and Prettier clean.
- **Manual (required before merge):** `createImageBitmap` defaults to `imageOrientation: 'from-image'`, which matches `<img>` decoding in Chromium (Figma is Chromium-only) — but worth confirming visually. Export a file containing an EXIF-rotated JPEG and a transparent PNG, and compare the render in Penpot before/after.

## Scope / trade-offs

- Memory + a small code simplification. **Output is unchanged** — same WebP format and quality, same dimensions.
- The only behavioural risk is EXIF orientation handling, covered by the manual check above.
