### PR TITLE
Fix external library detector

### DIFF
--- a/.changeset/external-libraries-ready-handshake.md
+++ b/.changeset/external-libraries-ready-handshake.md
@@ -2,4 +2,4 @@
 'penpot-exporter': patch
 ---
 
-Fix external library detection: the library list is now sent to the UI after it signals ready, so the prompt to link Penpot libraries no longer disappears when the team library data resolves before the UI has loaded.
+Fix a race condition that could prevent the external libraries prompt from appearing when opening the plugin.

--- a/.changeset/external-libraries-ready-handshake.md
+++ b/.changeset/external-libraries-ready-handshake.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Fix external library detection: the library list is now sent to the UI after it signals ready, so the prompt to link Penpot libraries no longer disappears when the team library data resolves before the UI has loaded.

--- a/plugin-src/code.ts
+++ b/plugin-src/code.ts
@@ -22,11 +22,36 @@ const sendEditorType = (): void => {
   });
 };
 
+const sendExternalLibraries = (): void => {
+  if (isSlidesEditor() || isFigJamEditor()) return;
+
+  figma.teamLibrary
+    .getAvailableLibraryVariableCollectionsAsync()
+    .then(collections => {
+      const libraryNames = Array.from(
+        new Set(
+          collections
+            .map(collection => collection.libraryName)
+            .filter((name): name is string => Boolean(name))
+        )
+      );
+
+      figma.ui.postMessage({
+        type: 'EXTERNAL_LIBRARIES',
+        data: libraryNames
+      });
+    })
+    .catch(error => {
+      console.warn('Could not fetch external libraries', error);
+    });
+};
+
 const onMessage: MessageEventHandler = message => {
   try {
     if (message.type === 'ready') {
       getUserData();
       sendEditorType();
+      sendExternalLibraries();
     }
 
     if (message.type === 'retry') {
@@ -57,25 +82,3 @@ const onMessage: MessageEventHandler = message => {
 
 figma.showUI(__html__, { themeColors: true, width: BASE_WIDTH, height: BASE_HEIGHT });
 figma.ui.onmessage = onMessage;
-
-if (!isSlidesEditor() && !isFigJamEditor()) {
-  figma.teamLibrary
-    .getAvailableLibraryVariableCollectionsAsync()
-    .then(collections => {
-      const libraryNames = Array.from(
-        new Set(
-          collections
-            .map(collection => collection.libraryName)
-            .filter((name): name is string => Boolean(name))
-        )
-      );
-
-      figma.ui.postMessage({
-        type: 'EXTERNAL_LIBRARIES',
-        data: libraryNames
-      });
-    })
-    .catch(error => {
-      console.warn('Could not fetch external libraries', error);
-    });
-}


### PR DESCRIPTION
## Problem

The plugin stopped detecting files with connected shared libraries: the "External Libraries" form (which asks for the Penpot library URL so the exported file stays linked) no longer appeared, even though the file had a team library with published variable collections enabled.

## Root cause

A race condition at plugin startup. The `EXTERNAL_LIBRARIES` message was posted from a top-level promise in `code.ts`, outside the `ready` handshake:

- Figma queues plugin → UI messages only until the iframe finishes loading, while the UI registers its `message` listener later, inside a Preact `useEffect`.
- If `getAvailableLibraryVariableCollectionsAsync()` resolves quickly (small or locally cached library), the message is delivered before the listener exists and is silently lost — no error, no log.
- With large libraries the call resolved slowly enough that the UI always won the race, which is why this went unnoticed until testing against a minimal library.

Verified that the Figma side works correctly: running `figma.teamLibrary.getAvailableLibraryVariableCollectionsAsync()` inside the affected consumer file returns the expected collection, so the data was there — the message just never reached the UI.

## Fix

Send `EXTERNAL_LIBRARIES` in response to the UI's `ready` message (new `sendExternalLibraries()`), exactly like `EDITOR_TYPE` and user data already do. The UI posts `ready` right after attaching its listener, so delivery order is guaranteed by design instead of by timing.

No behavior change otherwise: same detection logic, same slides/FigJam guard, same error handling.

## Testing

- Reproduced against a minimal test setup: a library file with 1 published component and a variable collection, and a consumer file using it — form did not appear before the fix, appears after.
- `npm run lint` ✓ · `npm run test:run` ✓ (321 tests) · dev build ✓

## Notes

Unrelated but discovered while debugging: detection relies on `getAvailableLibraryVariableCollectionsAsync()`, so libraries that publish only components/styles (no variable collections) are still not detectable — that is a Figma Plugin API limitation, unchanged by this PR.
