### PR TITLE
Fix "expected valid color" export failures (empty style names, degenerate gradients)

### DIFF
--- a/.changeset/sanitize-invalid-colors.md
+++ b/.changeset/sanitize-invalid-colors.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Fix "expected valid color" export failures: style names ending in "/" no longer produce empty asset names, and degenerate gradient transforms (handles almost on the same point) no longer produce coordinates outside the range Penpot accepts.

--- a/plugin-src/translators/styles/translateStyleName.ts
+++ b/plugin-src/translators/styles/translateStyleName.ts
@@ -1,9 +1,10 @@
+// Penpot rejects blank asset names, and Figma style names can end in "/"
+// (e.g. "Primary/"), leaving an empty last segment.
 export const translateStyleName = (figmaStyle: BaseStyle): string => {
-  const splitName = figmaStyle.name.split('/');
+  const lastNonBlankSegment = figmaStyle.name
+    .split('/')
+    .filter(segment => segment.trim().length > 0)
+    .pop();
 
-  if (splitName.length > 0) {
-    return splitName.pop() as string;
-  }
-
-  return figmaStyle.name;
+  return lastNonBlankSegment?.trim() ?? 'Untitled';
 };

--- a/plugin-src/utils/calculateLinearGradient.ts
+++ b/plugin-src/utils/calculateLinearGradient.ts
@@ -1,4 +1,5 @@
 import { applyMatrixToPoint } from '@plugin/utils/applyMatrixToPoint';
+import { clampToSafeNumber } from '@plugin/utils/clampToSafeNumber';
 import { matrixInvert } from '@plugin/utils/matrixInvert';
 
 export const calculateLinearGradient = (t: Transform): { start: number[]; end: number[] } => {
@@ -18,7 +19,7 @@ export const calculateLinearGradient = (t: Transform): { start: number[]; end: n
   ].map(p => applyMatrixToPoint(mxInv, p));
 
   return {
-    start: [startEnd[0][0], startEnd[0][1]],
-    end: [startEnd[1][0], startEnd[1][1]]
+    start: [clampToSafeNumber(startEnd[0][0]), clampToSafeNumber(startEnd[0][1])],
+    end: [clampToSafeNumber(startEnd[1][0]), clampToSafeNumber(startEnd[1][1])]
   };
 };

--- a/plugin-src/utils/calculateRadialGradient.ts
+++ b/plugin-src/utils/calculateRadialGradient.ts
@@ -1,4 +1,5 @@
 import { applyMatrixToPoint } from '@plugin/utils/applyMatrixToPoint';
+import { clampToSafeNumber } from '@plugin/utils/clampToSafeNumber';
 import { matrixInvert } from '@plugin/utils/matrixInvert';
 
 export const calculateRadialGradient = (t: Transform): { start: number[]; end: number[] } => {
@@ -25,9 +26,11 @@ export const calculateRadialGradient = (t: Transform): { start: number[]; end: n
   const angle =
     Math.atan((rxPoint[1] - centerPoint[1]) / (rxPoint[0] - centerPoint[0])) * (180 / Math.PI);
 
+  const endPoint = calculateRadialGradientEndPoint(angle, centerPoint, [rx, ry]);
+
   return {
-    start: centerPoint,
-    end: calculateRadialGradientEndPoint(angle, centerPoint, [rx, ry])
+    start: centerPoint.map(clampToSafeNumber),
+    end: endPoint.map(clampToSafeNumber)
   };
 };
 

--- a/plugin-src/utils/clampToSafeNumber.ts
+++ b/plugin-src/utils/clampToSafeNumber.ts
@@ -1,0 +1,12 @@
+export const PENPOT_SAFE_NUMBER_MIN = -2147483648;
+export const PENPOT_SAFE_NUMBER_MAX = 2147483647;
+
+/**
+ * Clamps a value to Penpot's "safe number" schema (int32 range), mapping `NaN`
+ * to `0`. A nearly-singular gradient transform inverts to coordinates far
+ * outside that range, which Penpot rejects ("expected valid color/shape").
+ */
+export const clampToSafeNumber = (value: number): number => {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(PENPOT_SAFE_NUMBER_MAX, Math.max(PENPOT_SAFE_NUMBER_MIN, value));
+};

--- a/plugin-src/utils/index.ts
+++ b/plugin-src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './applyMatrixToPoint';
 export * from './applyRotation';
 export * from './calculateLinearGradient';
 export * from './calculateRadialGradient';
+export * from './clampToSafeNumber';
 export * from './editorType';
 export * from './finiteOrUndefined';
 export * from './generateUuid';

--- a/tests/plugin-src/translators/styles/translateStyleName.test.ts
+++ b/tests/plugin-src/translators/styles/translateStyleName.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { translateStyleName } from '@plugin/translators/styles';
+
+const style = (name: string): BaseStyle => ({ name }) as BaseStyle;
+
+describe('translateStyleName', () => {
+  it('devuelve el nombre tal cual cuando no hay separadores', () => {
+    expect(translateStyleName(style('Primary'))).toBe('Primary');
+  });
+
+  it('devuelve el último segmento de un nombre con ruta', () => {
+    expect(translateStyleName(style('Brand/Primary'))).toBe('Primary');
+  });
+
+  it('ignora un segmento final vacío por barra al final', () => {
+    // Penpot rechaza nombres vacíos ("expected valid color")
+    expect(translateStyleName(style('Primary/'))).toBe('Primary');
+  });
+
+  it('ignora segmentos en blanco intermedios y finales', () => {
+    expect(translateStyleName(style('Brand//Primary/  /'))).toBe('Primary');
+  });
+
+  it('recorta espacios alrededor del segmento', () => {
+    expect(translateStyleName(style('Brand/ Primary '))).toBe('Primary');
+  });
+
+  it('usa un nombre por defecto si todos los segmentos están en blanco', () => {
+    expect(translateStyleName(style('/'))).toBe('Untitled');
+    expect(translateStyleName(style('   '))).toBe('Untitled');
+    expect(translateStyleName(style(''))).toBe('Untitled');
+  });
+});

--- a/tests/plugin-src/utils/calculateLinearGradient.test.ts
+++ b/tests/plugin-src/utils/calculateLinearGradient.test.ts
@@ -72,4 +72,19 @@ describe('calculateLinearGradient', () => {
     // Con escala 2x, el gradiente debería estar escalado
     expect(result.end[0]).toBeGreaterThan(result.start[0]);
   });
+
+  it('recorta coordenadas gigantes de una matriz casi singular', () => {
+    // Un gradiente degenerado (asas casi juntas) invierte a valores enormes
+    // que Penpot rechaza ("expected valid color")
+    const nearSingular: Transform = [
+      [1e-15, 0, 0],
+      [0, 1e-15, 0]
+    ];
+    const result = calculateLinearGradient(nearSingular);
+    for (const value of [...result.start, ...result.end]) {
+      expect(Number.isFinite(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(-2147483648);
+      expect(value).toBeLessThanOrEqual(2147483647);
+    }
+  });
 });

--- a/tests/plugin-src/utils/calculateRadialGradient.test.ts
+++ b/tests/plugin-src/utils/calculateRadialGradient.test.ts
@@ -85,4 +85,19 @@ describe('calculateRadialGradient', () => {
     expect(result.start[0]).not.toBe(0.5);
     expect(result.start[1]).not.toBe(0.5);
   });
+
+  it('recorta coordenadas gigantes de una matriz casi singular', () => {
+    // Un gradiente degenerado invierte a valores enormes o NaN
+    // que Penpot rechaza ("expected valid color")
+    const nearSingular: Transform = [
+      [1e-15, 0, 0],
+      [0, 1e-15, 0]
+    ];
+    const result = calculateRadialGradient(nearSingular);
+    for (const value of [...result.start, ...result.end]) {
+      expect(Number.isFinite(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(-2147483648);
+      expect(value).toBeLessThanOrEqual(2147483647);
+    }
+  });
 });

--- a/tests/plugin-src/utils/clampToSafeNumber.test.ts
+++ b/tests/plugin-src/utils/clampToSafeNumber.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PENPOT_SAFE_NUMBER_MAX,
+  PENPOT_SAFE_NUMBER_MIN,
+  clampToSafeNumber
+} from '@plugin/utils/clampToSafeNumber';
+
+describe('clampToSafeNumber', () => {
+  it('deja pasar valores dentro del rango', () => {
+    expect(clampToSafeNumber(0)).toBe(0);
+    expect(clampToSafeNumber(0.5)).toBe(0.5);
+    expect(clampToSafeNumber(-123.45)).toBe(-123.45);
+    expect(clampToSafeNumber(PENPOT_SAFE_NUMBER_MAX)).toBe(PENPOT_SAFE_NUMBER_MAX);
+    expect(clampToSafeNumber(PENPOT_SAFE_NUMBER_MIN)).toBe(PENPOT_SAFE_NUMBER_MIN);
+  });
+
+  it('recorta valores fuera del rango que Penpot acepta', () => {
+    expect(clampToSafeNumber(1e12)).toBe(PENPOT_SAFE_NUMBER_MAX);
+    expect(clampToSafeNumber(-1e12)).toBe(PENPOT_SAFE_NUMBER_MIN);
+    expect(clampToSafeNumber(Infinity)).toBe(PENPOT_SAFE_NUMBER_MAX);
+    expect(clampToSafeNumber(-Infinity)).toBe(PENPOT_SAFE_NUMBER_MIN);
+  });
+
+  it('convierte NaN en 0', () => {
+    expect(clampToSafeNumber(NaN)).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes two ways the exporter produces data that fails `@penpot/library` schema validation, aborting the whole export with `Exception: expected valid color` — as reported in #409, and one likely cause of the `expected valid shape` in #401 (an invalid fill inside a shape fails the shape schema).

**1. Style names ending in `/`.** `translateStyleName` returned the last `/`-segment of the Figma style name, so a style named `"Primary/"` translated to an empty asset name, which Penpot rejects. It now uses the last non-blank segment (trimmed), falling back to `"Untitled"`. This also covers text styles, which share the function.

**2. Degenerate gradient transforms.** When gradient handles are (almost) on the same point, `gradientTransform` is nearly singular and its inverse produces huge or `NaN` coordinates. Penpot's safe-number schema only accepts the int32 range (verified empirically against `@penpot/library` 1.2.0-RC2), so the export throws. Gradient coordinates are now clamped to that range (`NaN` → 0). The fully-singular case already had a fallback.

Both failures were reproduced end-to-end by feeding the translators' output into `penpot.createBuildContext().addLibraryColor(...)`: on `main` it throws `Exception: expected valid color`, with this change it passes. Unit tests added for `translateStyleName`, the new `clampToSafeNumber` util, and near-singular matrices in both gradient calculators. `npm run test:run` (332 passing) and `npm run lint` are clean. Changeset included (patch).

Two judgment calls I'm happy to change: the `"Untitled"` fallback name, and clamping (instead of falling back to the default `[0,0]→[0,0]` gradient like the non-invertible case) — clamping preserves the gradient direction.
