### PR TITLE
fix: restore nesting depth counter when a transform throws

### DIFF
--- a/.changeset/depth-counter-leak.md
+++ b/.changeset/depth-counter-leak.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Restore the internal nesting-depth counter with try/finally so an export aborted by an error no longer leaks state into the next export.

--- a/plugin-src/transformers/partials/transformChildren.ts
+++ b/plugin-src/transformers/partials/transformChildren.ts
@@ -36,20 +36,16 @@ export const transformChildren = async (node: ChildrenMixin): Promise<Children> 
   // to break the promise chain and allow garbage collection
   const shouldDefer = currentDepth > 5;
 
-  let children: PenpotNode[];
+  try {
+    const getChildren = (): Promise<PenpotNode[]> =>
+      containsMask
+        ? translateMaskChildren(node.children, maskIndex)
+        : translateChildren(node.children);
 
-  const getChildren = (): Promise<PenpotNode[]> =>
-    containsMask
-      ? translateMaskChildren(node.children, maskIndex)
-      : translateChildren(node.children);
+    const children = shouldDefer ? await deferToMacrotask(getChildren) : await getChildren();
 
-  if (shouldDefer) {
-    children = await deferToMacrotask(getChildren);
-  } else {
-    children = await getChildren();
+    return { children };
+  } finally {
+    transformChildrenDepth--;
   }
-
-  transformChildrenDepth--;
-
-  return { children };
 };

--- a/tests/plugin-src/transformers/partials/transformChildren.test.ts
+++ b/tests/plugin-src/transformers/partials/transformChildren.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { transformChildren } from '@plugin/transformers/partials/transformChildren';
+
+import type { PenpotNode } from '@ui/types';
+
+const { mockTranslateChildren, mockTranslateMaskChildren } = vi.hoisted(() => ({
+  mockTranslateChildren: vi.fn(),
+  mockTranslateMaskChildren: vi.fn()
+}));
+
+vi.mock('@plugin/translators', () => ({
+  translateChildren: mockTranslateChildren,
+  translateMaskChildren: mockTranslateMaskChildren
+}));
+
+const createNode = (depth = 1): ChildrenMixin => {
+  return {
+    children: depth > 1 ? [createNode(depth - 1)] : []
+  } as unknown as ChildrenMixin;
+};
+
+const transformNestedChildren = async (children: readonly SceneNode[]): Promise<PenpotNode[]> => {
+  for (const child of children) {
+    await transformChildren(child as unknown as ChildrenMixin);
+  }
+
+  return [];
+};
+
+describe('transformChildren', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTranslateChildren.mockResolvedValue([]);
+  });
+
+  it('restores the previous depth when a nested transformation throws', async () => {
+    const failingNode = createNode();
+    const rootWithFailingChild = {
+      children: [failingNode]
+    } as unknown as ChildrenMixin;
+
+    mockTranslateChildren.mockImplementationOnce(transformNestedChildren);
+    mockTranslateChildren.mockRejectedValueOnce(new Error('broken child'));
+
+    await expect(transformChildren(rootWithFailingChild)).rejects.toThrow('broken child');
+
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    mockTranslateChildren.mockImplementation(transformNestedChildren);
+
+    await transformChildren(createNode(4));
+
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+
+    setTimeoutSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Problem

`transformChildren` tracks nesting depth with a module-level counter decremented after the recursive call. If any transform throws mid-export, the decrement never runs: the counter leaks a wrong depth into the next export of the same plugin session, silently changing when the memory-relief macrotask deferral (depth > 5) kicks in.

## Change

Restore the counter with `try/finally` so it rebalances on both success and error. Behavior on the happy path is unchanged.

Found while investigating #408; extracted to its own PR to keep that one scoped to the Grid API incident.

## Testing

- New test: depth is restored after a nested transform throws.
- `npm run lint`, `npm run test:run` (322 tests) and `npm run build` pass. Changeset (patch) included.