### PR TITLE
fix: skip color library entries with no resolvable content

### DIFF
--- a/.changeset/skip-empty-color-assets.md
+++ b/.changeset/skip-empty-color-assets.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Skip color library entries with no resolvable color, gradient or image instead of aborting the export with "expected valid color".

--- a/ui-src/parser/builders/registerColorLibraries.ts
+++ b/ui-src/parser/builders/registerColorLibraries.ts
@@ -20,11 +20,23 @@ export const registerColorLibraries = async (
       const fill = fillStyle.fills[index];
       const color = fillStyle.colors[index];
 
+      const image = fill.fillImage ? symbolFillImage(context, fill.fillImage) : undefined;
+
+      // A color asset needs at least one of color, gradient or image; an entry can
+      // end up with none (e.g. its image bytes could not be fetched) and would be
+      // rejected by the Penpot library with "expected valid color".
+      if (fill.fillColor === undefined && fill.fillColorGradient === undefined && !image) {
+        console.warn(
+          `Penpot Exporter: skipped color library entry "${color.name}" with no resolvable content`
+        );
+        continue;
+      }
+
       const colorId = context.addLibraryColor({
         ...color,
         color: fill.fillColor,
         opacity: fill.fillOpacity,
-        image: fill.fillImage ? symbolFillImage(context, fill.fillImage) : undefined,
+        image,
         gradient: fill.fillColorGradient
       });
 


### PR DESCRIPTION
## Problem

A paint style whose only content fails to resolve — e.g. an image-type style whose bytes could not be fetched during the export — reached `context.addLibraryColor` with no `color`, no `gradient` and no `image`. `@penpot/library` rejects that asset with `Exception: expected valid color` (thrown with an empty `message`, text only in the stack), aborting the whole export at .penpot build time with no hint of the culprit.

Found while investigating #408: on files affected by that Figma platform bug, image fetches can fail silently mid-export, but any other cause of an unresolvable style content triggers the same crash.

## Change

Skip the empty entry and `console.warn` it instead of registering an invalid color asset. Everything else about the style pipeline is unchanged.

## Testing

- Field-tested on the file from #408: whole-file export now completes.
- `npm run lint`, `npm run test:run` and `npm run build` pass. Changeset (patch) included.