### PR TITLE
Clamp gradient values

### DIFF
--- a/.changeset/clamp-gradient-stop-offsets.md
+++ b/.changeset/clamp-gradient-stop-offsets.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Clamp gradient stop offsets to the [0, 1] range to match Figma UI behavior

--- a/plugin-src/translators/fills/gradients/translateGradientLinearFill.ts
+++ b/plugin-src/translators/fills/gradients/translateGradientLinearFill.ts
@@ -1,4 +1,4 @@
-import { calculateLinearGradient, rgbToHex } from '@plugin/utils';
+import { calculateLinearGradient, clamp, rgbToHex } from '@plugin/utils';
 
 import type { Fill } from '@ui/lib/types/utils/fill';
 
@@ -15,7 +15,7 @@ export const translateGradientLinearFill = (fill: GradientPaint): Fill => {
       width: 1,
       stops: fill.gradientStops.map(stop => ({
         color: rgbToHex(stop.color),
-        offset: stop.position,
+        offset: clamp(stop.position, 0, 1),
         opacity: stop.color.a * (fill.opacity ?? 1)
       }))
     },

--- a/plugin-src/translators/fills/gradients/translateGradientRadialFill.ts
+++ b/plugin-src/translators/fills/gradients/translateGradientRadialFill.ts
@@ -1,4 +1,4 @@
-import { calculateRadialGradient, rgbToHex } from '@plugin/utils';
+import { calculateRadialGradient, clamp, rgbToHex } from '@plugin/utils';
 
 import type { Fill } from '@ui/lib/types/utils/fill';
 
@@ -15,7 +15,7 @@ export const translateGradientRadialFill = (fill: GradientPaint): Fill => {
       width: 1,
       stops: fill.gradientStops.map(stop => ({
         color: rgbToHex(stop.color),
-        offset: stop.position,
+        offset: clamp(stop.position, 0, 1),
         opacity: stop.color.a * (fill.opacity ?? 1)
       }))
     },

--- a/plugin-src/utils/clamp.ts
+++ b/plugin-src/utils/clamp.ts
@@ -1,0 +1,7 @@
+/**
+ * Clamps a value to the [min, max] range. Figma can expose out-of-range
+ * values (e.g. gradient stop positions > 1 pasted via Figma Code),
+ * which Penpot rejects, so sanitize before passing values on.
+ */
+export const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);

--- a/plugin-src/utils/index.ts
+++ b/plugin-src/utils/index.ts
@@ -3,6 +3,7 @@ export * from './applyMatrixToPoint';
 export * from './applyRotation';
 export * from './calculateLinearGradient';
 export * from './calculateRadialGradient';
+export * from './clamp';
 export * from './editorType';
 export * from './finiteOrUndefined';
 export * from './generateUuid';

--- a/tests/plugin-src/translators/fills/gradients/translateGradientLinearFill.test.ts
+++ b/tests/plugin-src/translators/fills/gradients/translateGradientLinearFill.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { translateGradientLinearFill } from '@plugin/translators/fills/gradients/translateGradientLinearFill';
+
+const identity: Transform = [
+  [1, 0, 0],
+  [0, 1, 0]
+];
+
+describe('translateGradientLinearFill', () => {
+  it('keeps offsets unchanged for positions already within [0, 1]', () => {
+    const fill = {
+      type: 'GRADIENT_LINEAR',
+      gradientTransform: identity,
+      gradientStops: [
+        { position: 0, color: { r: 1, g: 0, b: 0, a: 1 } },
+        { position: 0.5, color: { r: 0, g: 1, b: 0, a: 1 } },
+        { position: 1, color: { r: 0, g: 0, b: 1, a: 1 } }
+      ]
+    } as GradientPaint;
+
+    const result = translateGradientLinearFill(fill);
+
+    expect(result.fillColorGradient?.stops.map(stop => stop.offset)).toEqual([0, 0.5, 1]);
+  });
+
+  it('clamps positions above 1 to 1 (issue #412: Code-to-Canvas out-of-range positions)', () => {
+    const fill = {
+      type: 'GRADIENT_LINEAR',
+      gradientTransform: identity,
+      gradientStops: [
+        { position: 100, color: { r: 1, g: 0, b: 0, a: 1 } },
+        { position: 1.05, color: { r: 0, g: 1, b: 0, a: 1 } }
+      ]
+    } as GradientPaint;
+
+    const result = translateGradientLinearFill(fill);
+
+    expect(result.fillColorGradient?.stops.map(stop => stop.offset)).toEqual([1, 1]);
+  });
+
+  it('clamps negative positions to 0', () => {
+    const fill = {
+      type: 'GRADIENT_LINEAR',
+      gradientTransform: identity,
+      gradientStops: [{ position: -0.5, color: { r: 1, g: 0, b: 0, a: 1 } }]
+    } as GradientPaint;
+
+    const result = translateGradientLinearFill(fill);
+
+    expect(result.fillColorGradient?.stops.map(stop => stop.offset)).toEqual([0]);
+  });
+
+  it('preserves color and opacity while clamping the offset', () => {
+    const fill = {
+      type: 'GRADIENT_LINEAR',
+      gradientTransform: identity,
+      opacity: 0.5,
+      gradientStops: [{ position: 100, color: { r: 1, g: 0, b: 0, a: 0.8 } }]
+    } as GradientPaint;
+
+    const result = translateGradientLinearFill(fill);
+    const [stop] = result.fillColorGradient?.stops ?? [];
+
+    expect(stop.offset).toBe(1);
+    expect(stop.color).toBe('#ff0000');
+    expect(stop.opacity).toBeCloseTo(0.4, 5);
+  });
+});

--- a/tests/plugin-src/translators/fills/gradients/translateGradientRadialFill.test.ts
+++ b/tests/plugin-src/translators/fills/gradients/translateGradientRadialFill.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { translateGradientRadialFill } from '@plugin/translators/fills/gradients/translateGradientRadialFill';
+
+const identity: Transform = [
+  [1, 0, 0],
+  [0, 1, 0]
+];
+
+describe('translateGradientRadialFill', () => {
+  it('keeps offsets unchanged for positions already within [0, 1]', () => {
+    const fill = {
+      type: 'GRADIENT_RADIAL',
+      gradientTransform: identity,
+      gradientStops: [
+        { position: 0, color: { r: 1, g: 0, b: 0, a: 1 } },
+        { position: 0.5, color: { r: 0, g: 1, b: 0, a: 1 } },
+        { position: 1, color: { r: 0, g: 0, b: 1, a: 1 } }
+      ]
+    } as GradientPaint;
+
+    const result = translateGradientRadialFill(fill);
+
+    expect(result.fillColorGradient?.stops.map(stop => stop.offset)).toEqual([0, 0.5, 1]);
+  });
+
+  it('clamps positions above 1 to 1 (issue #412: Code-to-Canvas out-of-range positions)', () => {
+    const fill = {
+      type: 'GRADIENT_RADIAL',
+      gradientTransform: identity,
+      gradientStops: [
+        { position: 100, color: { r: 1, g: 0, b: 0, a: 1 } },
+        { position: 1.05, color: { r: 0, g: 1, b: 0, a: 1 } }
+      ]
+    } as GradientPaint;
+
+    const result = translateGradientRadialFill(fill);
+
+    expect(result.fillColorGradient?.stops.map(stop => stop.offset)).toEqual([1, 1]);
+  });
+
+  it('clamps negative positions to 0', () => {
+    const fill = {
+      type: 'GRADIENT_RADIAL',
+      gradientTransform: identity,
+      gradientStops: [{ position: -0.5, color: { r: 1, g: 0, b: 0, a: 1 } }]
+    } as GradientPaint;
+
+    const result = translateGradientRadialFill(fill);
+
+    expect(result.fillColorGradient?.stops.map(stop => stop.offset)).toEqual([0]);
+  });
+
+  it('preserves color and opacity while clamping the offset', () => {
+    const fill = {
+      type: 'GRADIENT_RADIAL',
+      gradientTransform: identity,
+      opacity: 0.5,
+      gradientStops: [{ position: 100, color: { r: 1, g: 0, b: 0, a: 0.8 } }]
+    } as GradientPaint;
+
+    const result = translateGradientRadialFill(fill);
+    const [stop] = result.fillColorGradient?.stops ?? [];
+
+    expect(stop.offset).toBe(1);
+    expect(stop.color).toBe('#ff0000');
+    expect(stop.opacity).toBeCloseTo(0.4, 5);
+  });
+});

--- a/tests/plugin-src/utils/clamp.test.ts
+++ b/tests/plugin-src/utils/clamp.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { clamp } from '@plugin/utils';
+
+describe('clamp', () => {
+  it('returns values within the range unchanged', () => {
+    expect(clamp(0.5, 0, 1)).toBe(0.5);
+    expect(clamp(51, 0, 100)).toBe(51);
+    expect(clamp(-2, -5, 5)).toBe(-2);
+  });
+
+  it('returns max for values above the range', () => {
+    expect(clamp(100, 0, 1)).toBe(1);
+    expect(clamp(1.05, 0, 1)).toBe(1);
+  });
+
+  it('returns min for values below the range', () => {
+    expect(clamp(-0.5, 0, 1)).toBe(0);
+    expect(clamp(-10, -5, 5)).toBe(-5);
+  });
+
+  it('returns the exact boundary values unchanged', () => {
+    expect(clamp(0, 0, 1)).toBe(0);
+    expect(clamp(1, 0, 1)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #412. Figma's UI constrains gradient stop positions to the 0–100% range, but gradients created through Figma Code / copy-paste can carry `gradientStops` with positions outside `[0, 1]` (the reported file had positions like `100`). Both gradient translators assigned `stop.position` straight to Penpot's `offset`, and since Penpot validates `offset ∈ [0, 1]`, the whole export aborted with `Exception: expected valid shape`.

We normally don't support states that can't be created natively in Figma, but this one warrants a guard: it's cheap, and it applies the exact same normalization Figma's own UI enforces.

## Change

Clamp each stop position to `[0, 1]` before assigning it to `offset`, in both `translateGradientLinearFill` and `translateGradientRadialFill` — matching Figma UI behavior (e.g. 105% becomes 100%). No division by 100, no renormalization, no reordering: values already in range are untouched.

The guard lives in a new `clamp` util (`plugin-src/utils/clamp.ts`), following the existing `finiteOrUndefined` pattern of sanitizing out-of-contract Figma values at the boundary.

## Normalization policy

The issue asks whether out-of-range positions should be divided by 100 (percentage inference) or clamped independently. We chose clamping, based on the following:

- **The `[0, 1]` contract is real and enforced by Figma itself.** Writing `fills` through the Plugin API with `gradientStops[].position > 1` is rejected with `Property "fills" failed validation: Number must be less than or equal to 1`. There is no legitimate percentage-encoded scale anywhere in the public API: an out-of-range position is corrupt data that only internal ingest paths (the Code-to-Canvas copy in the MRE) can produce — not a different unit to be converted.
- **Clamping never touches valid values; percentage inference corrupts mixed sets.** For the issue's own example `[0, 0.5, 100]`, division yields `[0, 0.005, 1]` (destroying the valid `0.5`), while clamping yields `[0, 0.5, 1]`.
- **Clamping reproduces what Figma shows.** Figma's UI presents the MRE's raw positions as 0% / 100% stops and renders the canvas accordingly; clamping exports that same gradient to Penpot. (For the MRE's values — only `0` and `100` — both policies happen to coincide.)
- **In-range gradients round-trip untouched**: field-tested a native 0% / 0% / 50% / 50% slider gradient — it exports with offsets `[0, 0, 0.5, 0.5]` and renders identically in Penpot.

## Testing

- New unit tests for both gradient translators: in-range positions preserved, positions above 1 clamp to 1 (the #412 case), negatives clamp to 0, color/opacity unaffected.
- New unit test for the `clamp` util (range, boundaries).
- Field-tested in Figma + Penpot import (see policy section above).
- `npm run lint` and `npm run test:run` (342 tests) pass. Changeset (patch) included.
