### PR TITLE
fix(export): contain two new manifestations of the Figma grid corruption bug

### DIFF
--- a/.changeset/degrade-grid-on-figma-validation-errors.md
+++ b/.changeset/degrade-grid-on-figma-validation-errors.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Recognize Figma's grid-corruption validation errors generically and detect corrupted grid track data so affected grid layers degrade gracefully instead of aborting the export.

--- a/plugin-src/translators/translateLayout.ts
+++ b/plugin-src/translators/translateLayout.ts
@@ -1,4 +1,5 @@
 import { transformId } from '@plugin/transformers/partials';
+import { FigmaPlatformDataError } from '@plugin/utils/figmaPlatformError';
 import { generateUuid } from '@plugin/utils/generateUuid';
 
 import type {
@@ -237,6 +238,10 @@ export const translateLayoutItemAlignSelf = (align: FigmaLayoutAlign): LayoutAli
 };
 
 const translateGridTrack = (gridTrack: GridTrackSize): GridTrack => {
+  if (gridTrack == null || typeof gridTrack.value !== 'number') {
+    throw new FigmaPlatformDataError('Grid track read returned corrupted data');
+  }
+
   return {
     type: gridTrack.type === 'FLEX' ? 'flex' : 'fixed',
     value: gridTrack.value

--- a/plugin-src/utils/figmaPlatformError.ts
+++ b/plugin-src/utils/figmaPlatformError.ts
@@ -1,13 +1,20 @@
 // Known error signatures of an internal Figma platform failure that corrupts
 // property reads on (mostly virtual) nodes after enough export work in one run.
-// Observed with Grid auto-layout files; see PR #408. Anything else must propagate.
+// Observed with Grid auto-layout files; validation failures match generically. See PR #408. Anything else must propagate.
 const FIGMA_PLATFORM_ERROR_SIGNATURES = [
   'Attempted to invoke callback with invalid id',
   'Expected node id to be a string, got undefined',
-  'Property "gridItemsPositioning" failed validation'
+  'failed validation'
 ] as const;
 
+// Marks data reads that returned impossible values per Plugin API typings; same grid-corruption family. See PR #408.
+export class FigmaPlatformDataError extends Error {}
+
 export const isFigmaPlatformError = (error: unknown): boolean => {
+  if (error instanceof FigmaPlatformDataError) {
+    return true;
+  }
+
   const message = error instanceof Error ? error.message : String(error);
 
   return FIGMA_PLATFORM_ERROR_SIGNATURES.some(signature => message.includes(signature));

--- a/tests/plugin-src/translators/translateGridTracks.test.ts
+++ b/tests/plugin-src/translators/translateGridTracks.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { translateGridTracks } from '@plugin/translators/translateLayout';
+import { FigmaPlatformDataError } from '@plugin/utils/figmaPlatformError';
+
+describe('translateGridTracks', () => {
+  it('translates flex and fixed grid tracks', () => {
+    expect(
+      translateGridTracks([
+        { type: 'FLEX', value: 1 },
+        { type: 'FIXED', value: 100 }
+      ])
+    ).toEqual([
+      { type: 'flex', value: 1 },
+      { type: 'fixed', value: 100 }
+    ]);
+  });
+
+  it('throws a platform data error for undefined tracks', () => {
+    expect(() => translateGridTracks([undefined as unknown as GridTrackSize])).toThrow(
+      FigmaPlatformDataError
+    );
+  });
+
+  it('throws a platform data error for tracks without numeric values', () => {
+    expect(() => translateGridTracks([{ type: 'FLEX' } as GridTrackSize])).toThrow(
+      FigmaPlatformDataError
+    );
+  });
+});

--- a/tests/plugin-src/utils/figmaPlatformError.test.ts
+++ b/tests/plugin-src/utils/figmaPlatformError.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isFigmaPlatformError } from '@plugin/utils/figmaPlatformError';
+import { FigmaPlatformDataError, isFigmaPlatformError } from '@plugin/utils/figmaPlatformError';
 
 describe('isFigmaPlatformError', () => {
   it('recognizes the callback ID signature', () => {
@@ -21,11 +21,31 @@ describe('isFigmaPlatformError', () => {
     ).toBe(true);
   });
 
-  it('recognizes the grid item positioning signature from non-Error values', () => {
+  it('recognizes the grid item positioning validation signature from non-Error values', () => {
     expect(
       isFigmaPlatformError(
         'Property "gridItemsPositioning" failed validation: Required value missing'
       )
     ).toBe(true);
+  });
+
+  it('recognizes component property validation signatures', () => {
+    expect(
+      isFigmaPlatformError(
+        new Error(
+          'in set_componentPropertyReferences: Property "node.componentPropertyReferences.value" failed validation: Required value missing'
+        )
+      )
+    ).toBe(true);
+  });
+
+  it('recognizes platform data errors', () => {
+    expect(isFigmaPlatformError(new FigmaPlatformDataError('x'))).toBe(true);
+  });
+
+  it('does not recognize unrelated errors', () => {
+    expect(
+      isFigmaPlatformError(new TypeError("Cannot read properties of undefined (reading 'value')"))
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Exporting a large Grid auto-layout file aborts during `processing` with two new errors, both surfacing in the per-track reads inside `transformAutoLayout`:

1. `in set_componentPropertyReferences: Property "node.componentPropertyReferences.value" failed validation: Required value missing` — thrown by Figma while reading `gridRowSizes`/`gridColumnSizes` track properties (the plugin never writes that property; the validator reports against an unrelated one).
2. `cannot read property 'type' of undefined` — Figma returns the track array with an `undefined` element, so `translateGridTrack` throws a plain plugin-side `TypeError`.

## Root cause

Both are new manifestations of the internal Figma Plugin API corruption documented in #408: after enough export work in one run, per-track grid property reads break (positionally, not per-node, and permanently for the rest of the run). The existing grid guard already degrades affected layers, but only for the exact signatures known at the time — these two manifestations slipped through `isFigmaPlatformError` and aborted the whole export.

Stack traces from both failures were mapped against a rebuilt v0.24.2 production bundle and land in `translateGridTracks` → `translateGridAttributes` → `transformAutoLayout`, i.e. exactly the guarded path. A full MCP sweep of the failing file (52,781 nodes) confirmed the document itself is healthy — the corruption is transient, per-run, inside the plugin sandbox.

## Changes

1. **Generalize the validation signature** (`figmaPlatformError.ts`): `'Property "gridItemsPositioning" failed validation'` → `'failed validation'`. The corruption reports validation failures against arbitrary property names, so chasing per-property signatures is a losing game. The matcher is only consulted inside the grid guard, so the blast radius stays contained.
2. **Detect corrupted track data at the boundary** (`translateLayout.ts`): a track element that is `undefined` or lacks a numeric `value` is impossible per the Plugin API typings, so `translateGridTrack` now throws a typed `FigmaPlatformDataError`, which `isFigmaPlatformError` recognizes via `instanceof`. Generic `TypeError`s remain unmatched on purpose — a new negative test enshrines that our own bugs are never mislabeled or masked.

Affected layers keep degrading exactly as introduced in #408 (default `1fr` tracks, or plain frame as last resort) and stay listed in the export summary banner.

## Testing

- New unit tests: generalized signature matches the observed production message; `FigmaPlatformDataError` is recognized; corrupted tracks (`undefined` element, missing numeric `value`) throw it; generic `TypeError` still does NOT match.
- `npm run lint` and `npm run test:run` pass (348 tests).
- Verified against the real-world failing file (~52k nodes, hundreds of grid frames): the export previously aborted on both errors and now completes, with the affected grid layers listed as degraded.

Includes a patch changeset.