### PR TITLE
fix: allow self-hosted Penpot instance URLs in the External Libraries field

### DIFF
--- a/.changeset/self-hosted-library-urls.md
+++ b/.changeset/self-hosted-library-urls.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Allow self-hosted Penpot instance URLs in the External Libraries field. The URL validation no longer requires "penpot" in the domain, so on-prem installations (e.g. http://localhost:9001) can link external libraries. Fixes #398.

--- a/.changeset/self-hosted-library-urls.md
+++ b/.changeset/self-hosted-library-urls.md
@@ -2,4 +2,4 @@
 'penpot-exporter': patch
 ---
 
-Allow self-hosted Penpot instance URLs in the External Libraries field. The URL validation no longer requires "penpot" in the domain, so on-prem installations (e.g. http://localhost:9001) can link external libraries. Fixes #398.
+Allow self-hosted Penpot instance URLs in the External Libraries field instead of rejecting any domain without "penpot" in it.

--- a/tests/ui-src/utils/validatePenpotUrl.test.ts
+++ b/tests/ui-src/utils/validatePenpotUrl.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractFileIdFromPenpotUrl, validatePenpotUrl } from '@ui/utils/validatePenpotUrl';
+
+const FILE_ID = 'c7f0d1de-77e4-80e0-8007-32b4b1bbd8b1';
+
+describe('validatePenpotUrl', () => {
+  it('accepts an empty value', () => {
+    expect(validatePenpotUrl('')).toBe(true);
+    expect(validatePenpotUrl('   ')).toBe(true);
+    expect(validatePenpotUrl(undefined)).toBe(true);
+  });
+
+  it('accepts a Penpot SaaS URL with a file-id in the hash', () => {
+    expect(
+      validatePenpotUrl(
+        `https://design.penpot.app/#/workspace?team-id=${FILE_ID}&file-id=${FILE_ID}&page-id=${FILE_ID}`
+      )
+    ).toBe(true);
+  });
+
+  it('accepts a self-hosted localhost URL', () => {
+    expect(
+      validatePenpotUrl(`http://localhost:9001/#/workspace?team-id=${FILE_ID}&file-id=${FILE_ID}`)
+    ).toBe(true);
+  });
+
+  it('accepts a self-hosted URL without "penpot" in the domain', () => {
+    expect(validatePenpotUrl(`https://design.example.com/#/workspace?file-id=${FILE_ID}`)).toBe(
+      true
+    );
+  });
+
+  it('accepts a file-id in the query string instead of the hash', () => {
+    expect(validatePenpotUrl(`https://design.penpot.app/view?file-id=${FILE_ID}`)).toBe(true);
+  });
+
+  it('rejects a URL without a file-id parameter', () => {
+    expect(validatePenpotUrl('http://localhost:9001/#/workspace?team-id=1')).toBe(
+      'URL must contain a file-id parameter'
+    );
+  });
+
+  it('rejects a URL with an invalid file-id', () => {
+    expect(validatePenpotUrl('https://design.penpot.app/#/workspace?file-id=not-a-uuid')).toBe(
+      'The file-id in the URL is not valid'
+    );
+  });
+
+  it('rejects non-http(s) protocols', () => {
+    expect(validatePenpotUrl(`ftp://design.penpot.app/#/workspace?file-id=${FILE_ID}`)).toBe(
+      'Enter a valid Penpot URL (e.g., https://design.penpot.app/#/... or your self-hosted instance URL)'
+    );
+  });
+
+  it('rejects plain text that is not a URL', () => {
+    expect(validatePenpotUrl('not a url')).toBe('Invalid URL format');
+  });
+});
+
+describe('extractFileIdFromPenpotUrl', () => {
+  it('extracts the file-id from a valid URL', () => {
+    expect(extractFileIdFromPenpotUrl(`http://localhost:9001/#/workspace?file-id=${FILE_ID}`)).toBe(
+      FILE_ID
+    );
+  });
+
+  it('returns undefined for an invalid URL', () => {
+    expect(extractFileIdFromPenpotUrl('not a url')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty value', () => {
+    expect(extractFileIdFromPenpotUrl('')).toBeUndefined();
+  });
+});

--- a/tests/ui-src/utils/validatePenpotUrl.test.ts
+++ b/tests/ui-src/utils/validatePenpotUrl.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractFileIdFromPenpotUrl, validatePenpotUrl } from '@ui/utils/validatePenpotUrl';
+import {
+  extractFileIdFromPenpotUrl,
+  isSelfHostedPenpotUrl,
+  validatePenpotUrl
+} from '@ui/utils/validatePenpotUrl';
 
 const FILE_ID = 'c7f0d1de-77e4-80e0-8007-32b4b1bbd8b1';
 
@@ -71,5 +75,33 @@ describe('extractFileIdFromPenpotUrl', () => {
 
   it('returns undefined for an empty value', () => {
     expect(extractFileIdFromPenpotUrl('')).toBeUndefined();
+  });
+});
+
+describe('isSelfHostedPenpotUrl', () => {
+  it('returns false for official penpot.app URLs', () => {
+    expect(isSelfHostedPenpotUrl(`https://design.penpot.app/#/workspace?file-id=${FILE_ID}`)).toBe(
+      false
+    );
+    expect(isSelfHostedPenpotUrl('https://penpot.app/')).toBe(false);
+  });
+
+  it('returns true for self-hosted instance URLs', () => {
+    expect(isSelfHostedPenpotUrl(`http://localhost:9001/#/workspace?file-id=${FILE_ID}`)).toBe(
+      true
+    );
+    expect(isSelfHostedPenpotUrl('https://penpot.example.com/#/workspace')).toBe(true);
+  });
+
+  it('treats lookalike domains as self-hosted', () => {
+    expect(isSelfHostedPenpotUrl('https://not-penpot.app/')).toBe(true);
+    expect(isSelfHostedPenpotUrl('https://evilpenpot.app/')).toBe(true);
+  });
+
+  it('returns false for values that are not http(s) URLs', () => {
+    expect(isSelfHostedPenpotUrl('')).toBe(false);
+    expect(isSelfHostedPenpotUrl(undefined)).toBe(false);
+    expect(isSelfHostedPenpotUrl('not a url')).toBe(false);
+    expect(isSelfHostedPenpotUrl('ftp://penpot.example.com/')).toBe(false);
   });
 });

--- a/ui-src/components/ExternalLibrariesFieldSet.tsx
+++ b/ui-src/components/ExternalLibrariesFieldSet.tsx
@@ -4,11 +4,12 @@ import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 
 import { Stack } from '@ui/components/Stack';
 import type { FormValues } from '@ui/context';
-import { validatePenpotUrl } from '@ui/utils';
+import { isSelfHostedPenpotUrl, validatePenpotUrl } from '@ui/utils';
 
 export const ExternalLibrariesFieldSet = (): JSX.Element => {
   const {
     control,
+    watch,
     formState: { errors }
   } = useFormContext<FormValues>();
 
@@ -50,6 +51,7 @@ export const ExternalLibrariesFieldSet = (): JSX.Element => {
 
       {fields.map((field, index) => {
         const fieldError = errors.externalLibraries?.[index]?.uuid;
+        const fieldValue = watch(`externalLibraries.${index}.uuid`);
 
         return (
           <Stack key={field.id} space="2xsmall">
@@ -76,6 +78,12 @@ export const ExternalLibrariesFieldSet = (): JSX.Element => {
             {fieldError && (
               <span style={{ fontSize: 11, color: 'var(--figma-color-text-danger)' }}>
                 {fieldError.message}
+              </span>
+            )}
+            {!fieldError && isSelfHostedPenpotUrl(fieldValue) && (
+              <span style={{ fontSize: 11, color: 'var(--figma-color-text-warning)' }}>
+                This URL points to a self-hosted Penpot instance. The library and the files that use
+                it must live in the same instance.
               </span>
             )}
           </Stack>

--- a/ui-src/utils/validatePenpotUrl.ts
+++ b/ui-src/utils/validatePenpotUrl.ts
@@ -1,5 +1,4 @@
 const UUID_REGEX = /^$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const PENPOT_URL_REGEX = /^https?:\/\/[^/]*penpot[^/]*\//i;
 
 type ParseResult = { success: true; fileId: string } | { success: false; error: string };
 
@@ -20,15 +19,17 @@ const parsePenpotUrl = (input: string): ParseResult => {
     return { success: true, fileId: '' };
   }
 
-  if (!PENPOT_URL_REGEX.test(trimmed)) {
-    return {
-      success: false,
-      error: 'Enter a valid Penpot URL (e.g., https://design.penpot.app/#/...)'
-    };
-  }
-
   try {
     const url = new URL(trimmed);
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return {
+        success: false,
+        error:
+          'Enter a valid Penpot URL (e.g., https://design.penpot.app/#/... or your self-hosted instance URL)'
+      };
+    }
+
     const hashParams = new URLSearchParams(url.hash.split('?')[1] || '');
     const searchParams = url.searchParams;
     const fileId = hashParams.get('file-id') || searchParams.get('file-id');

--- a/ui-src/utils/validatePenpotUrl.ts
+++ b/ui-src/utils/validatePenpotUrl.ts
@@ -7,6 +7,20 @@ export const validatePenpotUrl = (value: string | undefined): string | true => {
   return result.success ? true : result.error;
 };
 
+export const isSelfHostedPenpotUrl = (value: string | undefined): boolean => {
+  try {
+    const url = new URL((value ?? '').trim());
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return false;
+    }
+
+    return url.hostname !== 'penpot.app' && !url.hostname.endsWith('.penpot.app');
+  } catch {
+    return false;
+  }
+};
+
 export const extractFileIdFromPenpotUrl = (url: string): string | undefined => {
   const result = parsePenpotUrl(url);
   return result.success && result.fileId ? result.fileId : undefined;


### PR DESCRIPTION
## Problem

The External Libraries field in the export view validates the library URL with a regex that requires the literal string "penpot" in the domain:

```ts
const PENPOT_URL_REGEX = /^https?:\/\/[^/]*penpot[^/]*\//i;
```

`https://design.penpot.app/...` passes, but any self-hosted instance URL — `http://localhost:9001/#/workspace?...` or an on-prem domain without "penpot" in it — is rejected with *"Enter a valid Penpot URL"*, so on-prem users cannot link external libraries at all.

The domain check adds no value: only the extracted `file-id` is used downstream (`extractFileIdFromPenpotUrl` → export message), the URL itself is discarded, and the meaningful validation (well-formed URL, `file-id` present, valid UUID) already happens after the regex.

Fixes #398

## Change

Drop the domain regex from `validatePenpotUrl.ts`. The URL is now parsed with `new URL()` and only the protocol is checked (`http:`/`https:`); the existing `file-id` presence and UUID checks are unchanged. The validation error message now mentions self-hosted instances.

When the URL points to a non-official instance, an informational warning is shown under the field: the library and the files that use it must live in the same Penpot instance.

Note: the exact URL from the issue screenshot (`...?team-id=1`, no `file-id`) still fails, but now with the accurate message *"URL must contain a file-id parameter"* — a URL without a `file-id` cannot link a library.

## Testing

- New unit tests for `validatePenpotUrl` / `extractFileIdFromPenpotUrl` (previously untested): SaaS URLs, localhost and on-prem domains, `file-id` in hash and query string, missing/invalid `file-id`, non-http(s) protocols, malformed input.
- `npm run lint`, `npm run test:run` (333 tests) and `npm run build` pass.

Includes a patch changeset.

