### PR TITLE
fix(export): fall back to a default font family when a text style has no resolvable fontName

### DIFF
--- a/.changeset/fallback-font-family-unresolvable-text-style.md
+++ b/.changeset/fallback-font-family-unresolvable-text-style.md
@@ -2,4 +2,4 @@
 'penpot-exporter': patch
 ---
 
-Fall back to a default font family when a text style (typically a remote library style) has no resolvable `fontName`, so the exported typography passes Penpot's schema validation and the import no longer fails with a missing `font-family`. Also stop registering an undefined family in the missing-fonts list.
+Fall back to a default font family for text styles with no resolvable font name instead of exporting typographies Penpot rejects with a missing `font-family`.

--- a/.changeset/fallback-font-family-unresolvable-text-style.md
+++ b/.changeset/fallback-font-family-unresolvable-text-style.md
@@ -1,0 +1,5 @@
+---
+'penpot-exporter': patch
+---
+
+Fall back to a default font family when a text style (typically a remote library style) has no resolvable `fontName`, so the exported typography passes Penpot's schema validation and the import no longer fails with a missing `font-family`. Also stop registering an undefined family in the missing-fonts list.

--- a/plugin-src/translators/styles/translateTextStyle.ts
+++ b/plugin-src/translators/styles/translateTextStyle.ts
@@ -15,7 +15,9 @@ export const translateTextStyle = (figmaStyle: TextStyle): TypographyStyle => {
     name: translateStyleName(figmaStyle),
     textStyle: {
       ...translateFontName(figmaStyle.fontName),
-      fontFamily: figmaStyle.fontName.family,
+      // Figma can return remote library text styles with an unresolvable fontName
+      // (missing or empty family); Penpot requires font-family to be a non-empty string.
+      fontFamily: figmaStyle.fontName?.family || 'sourcesanspro',
       fontSize: figmaStyle.fontSize.toString(),
       fontStyle: translateFontStyle(figmaStyle),
       textDecoration: translateTextDecoration(figmaStyle),

--- a/plugin-src/translators/styles/translateTextStyle.ts
+++ b/plugin-src/translators/styles/translateTextStyle.ts
@@ -15,9 +15,8 @@ export const translateTextStyle = (figmaStyle: TextStyle): TypographyStyle => {
     name: translateStyleName(figmaStyle),
     textStyle: {
       ...translateFontName(figmaStyle.fontName),
-      // Figma can return remote library text styles with an unresolvable fontName
-      // (missing or empty family); Penpot requires font-family to be a non-empty string.
-      fontFamily: figmaStyle.fontName?.family || 'sourcesanspro',
+      // Figma can return remote text styles without a usable fontName; Penpot requires font-family.
+      fontFamily: figmaStyle.fontName?.family ?? 'sourcesanspro',
       fontSize: figmaStyle.fontSize.toString(),
       fontStyle: translateFontStyle(figmaStyle),
       textDecoration: translateTextDecoration(figmaStyle),

--- a/plugin-src/translators/text/font/custom/translateCustomFont.ts
+++ b/plugin-src/translators/text/font/custom/translateCustomFont.ts
@@ -7,7 +7,7 @@ export const translateCustomFont = (
   fontName: FontName | undefined,
   fontWeight: string
 ): Pick<TextTypography, 'fontId' | 'fontVariantId' | 'fontWeight'> | undefined => {
-  if (fontName) {
+  if (fontName?.family) {
     missingFonts.add(fontName.family);
   }
 

--- a/tests/plugin-src/translators/styles/translateTextStyle.test.ts
+++ b/tests/plugin-src/translators/styles/translateTextStyle.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { translateStyleName } from '@plugin/translators/styles/translateStyleName';
+import { translateTextStyle } from '@plugin/translators/styles/translateTextStyle';
+
+vi.mock('@plugin/libraries', () => ({
+  missingFonts: new Set<string>(),
+  textStyles: new Map()
+}));
+
+// @ts-expect-error - Mocking global figma object (non-FigJam editor)
+global.figma = { editorType: 'figma' };
+
+const createTextStyle = (overrides: Partial<TextStyle> = {}): TextStyle =>
+  ({
+    type: 'TEXT',
+    id: 'S:abc,',
+    name: 'Heading 1 (40) ',
+    remote: true,
+    fontName: { family: 'Roboto', style: 'Bold' },
+    fontSize: 40,
+    textDecoration: 'NONE',
+    textCase: 'ORIGINAL',
+    letterSpacing: { unit: 'PERCENT', value: 0 },
+    lineHeight: { unit: 'AUTO' },
+    ...overrides
+  }) as unknown as TextStyle;
+
+describe('translateTextStyle', () => {
+  let missingFonts: Set<string>;
+
+  beforeEach(async () => {
+    const libraries = await import('@plugin/libraries');
+    missingFonts = libraries.missingFonts;
+    missingFonts.clear();
+  });
+
+  it('does not throw and falls back to the default font family when fontName is undefined', () => {
+    const figmaStyle = createTextStyle({ fontName: undefined as unknown as FontName });
+
+    expect(() => translateTextStyle(figmaStyle)).not.toThrow();
+
+    const result = translateTextStyle(figmaStyle);
+    expect(result.textStyle.fontFamily).toBe('sourcesanspro');
+    expect(result.textStyle.fontId).toBe('');
+    expect(result.textStyle.fontVariantId).toBe('normal-400');
+    expect(result.textStyle.fontWeight).toBe('400');
+    expect(result.textStyle.fontStyle).toBe('normal');
+    expect(result.textStyle.fontSize).toBe('40');
+  });
+
+  it('falls back to the default font family when fontName has no usable family/style (remote style edge case), without recording a missing font', () => {
+    const figmaStyle = createTextStyle({ fontName: {} as FontName });
+
+    const result = translateTextStyle(figmaStyle);
+
+    expect(result.textStyle.fontFamily).toBe('sourcesanspro');
+    expect(result.textStyle.fontId).toBe('');
+    expect(result.textStyle.fontVariantId).toBe('normal-400');
+    expect(result.textStyle.fontWeight).toBe('400');
+    expect(result.textStyle.fontStyle).toBe('normal');
+    expect(result.textStyle.fontSize).toBe('40');
+
+    expect(missingFonts.size).toBe(0);
+    expect(missingFonts.has(undefined as unknown as string)).toBe(false);
+  });
+
+  it('translates a healthy remote Google Font style', () => {
+    const figmaStyle = createTextStyle({
+      remote: true,
+      fontName: { family: 'Roboto', style: 'Bold' }
+    });
+
+    const result = translateTextStyle(figmaStyle);
+
+    expect(result.textStyle.fontFamily).toBe('Roboto');
+    expect(result.textStyle.fontId).toBe('gfont-roboto');
+    expect(result.textStyle.fontWeight).toBe('700');
+    expect(result.typography.path).toBe('Remote');
+    expect(result.typography.name).toBe(translateStyleName(figmaStyle));
+  });
+
+  it('registers a custom font family not found in the google/local font lists as missing (regression guard)', () => {
+    const figmaStyle = createTextStyle({
+      fontName: { family: 'Acme Sans', style: 'Regular' }
+    });
+
+    const result = translateTextStyle(figmaStyle);
+
+    expect(result.textStyle.fontFamily).toBe('Acme Sans');
+    expect(result.textStyle.fontId).toBe('');
+    expect(missingFonts.has('Acme Sans')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Exports containing certain **remote library text styles** could not be imported into Penpot. The import aborted with:

```
[{:path [:font-family], :type :malli.core/missing-key}]
Value: {:font-id "", :font-weight "400", :font-variant-id "normal-400", :name "Heading 1 (40) ", :path "Remote", ...}
```

## Root cause

For some remote text styles, Figma's `getStyleByIdAsync` returns a `TextStyle` whose `fontName` has no usable `family`/`style`, while `fontSize`, `lineHeight` and `letterSpacing` are populated. `translateTextStyle` copied `figmaStyle.fontName.family` verbatim, so the typography was emitted **without `fontFamily`** (and with the custom-font defaults `fontId: ""`, `fontWeight: "400"`, `fontVariantId: "normal-400"`). Penpot's `Typography` schema requires `font-family` as a string, so the whole file was rejected.

Text nodes bound to those styles inherited `fontFamily: null` through the UI merge as well. In the reported file, 7 of 10 remote typographies were affected, along with 1289 text nodes referencing exactly those 7.

## Changes

- `translateTextStyle`: fall back to `sourcesanspro` when the family is missing or empty, mirroring the existing fallback in the text-segment path (`translateTextSegments.ts`).
- `translateCustomFont`: only register a family in `missingFonts` when it is a non-empty string, so the UI no longer lists an `undefined` custom font for these styles.
- New tests in `tests/plugin-src/translators/styles/translateTextStyle.test.ts`: `fontName` undefined, `fontName` without family/style (the observed remote-style shape), a healthy remote Google Font, and a custom-family regression guard.
- Patch changeset.

## Test plan

- [x] New tests fail on `main` (case 1 throws `TypeError`, case 2 yields `fontFamily: undefined`) and pass with the fix.
- [x] `npm run test:run`: 55 files, 352 tests passing.
- [x] `npm run lint`: clean.
- [x] The affected `.penpot` export, patched to match the fixed output (7 typographies + 1289 text nodes set to `sourcesanspro`), imports successfully into Penpot.

## Notes

The 7 affected typographies import with Source Sans Pro / weight 400 and an empty `fontId`, since Figma provides nothing better for them. Text nodes bound to them keep their real font through their own `fontId`/`fontVariantId`. Why Figma returns these remote styles incomplete is not documented; it likely relates to the source library being unlinked or inaccessible.
