### PR TITLE
fix: keep the fills and strokes of boolean operations

### DIFF
--- a/tests/ui-src/parser/creators/createBool.test.ts
+++ b/tests/ui-src/parser/creators/createBool.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PenpotContext } from '@ui/lib/types/penpotContext';
+import type { BoolOperations, BoolShape } from '@ui/lib/types/shapes/boolShape';
+import type { Fill } from '@ui/lib/types/utils/fill';
+import type { Stroke } from '@ui/lib/types/utils/stroke';
+import { colors } from '@ui/parser';
+import { createBool } from '@ui/parser/creators/createBool';
+import type { PenpotNode } from '@ui/types';
+
+vi.mock('@ui/parser', () => ({
+  colors: new Map(),
+  images: new Map(),
+  components: new Map(),
+  componentRoots: new Map(),
+  componentProperties: new Map(),
+  typographies: new Map()
+}));
+
+const addGroup = vi.fn().mockReturnValue('group-id');
+const addPath = vi.fn();
+const addRect = vi.fn();
+const addBoard = vi.fn();
+
+const context = {
+  addGroup,
+  closeGroup: vi.fn(),
+  addBool: vi.fn(),
+  addPath,
+  addRect,
+  addBoard,
+  closeBoard: vi.fn()
+} as unknown as PenpotContext;
+
+const black: Fill[] = [{ fillColor: '#000000', fillOpacity: 1 }];
+const white: Fill[] = [{ fillColor: '#ffffff', fillOpacity: 1 }];
+const strokes: Stroke[] = [{ strokeColor: '#ff0000', strokeWidth: 2 }];
+
+const path = (name: string, fills: Fill[] = []): PenpotNode =>
+  ({ type: 'path', name, fills, content: [] }) as unknown as PenpotNode;
+
+const board = (name: string): PenpotNode =>
+  ({ type: 'frame', name, fills: white, children: [] }) as unknown as PenpotNode;
+
+const bool = (
+  boolType: BoolOperations,
+  children: PenpotNode[],
+  attributes: Partial<BoolShape> = {}
+): BoolShape =>
+  ({
+    type: 'bool',
+    name: 'Bool',
+    boolType,
+    fills: black,
+    children,
+    ...attributes
+  }) as BoolShape;
+
+const addPathCall = (index: number): Record<string, unknown> => addPath.mock.calls[index][0];
+
+describe('createBool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    colors.clear();
+  });
+
+  // Penpot discards the appearance set on the bool itself and inherits it from one
+  // of the children instead: the first one for a difference, the last one for every
+  // other operation.
+  it('propagates the fills to the first child of a difference', () => {
+    createBool(context, bool('difference', [path('first'), path('last', white)]));
+
+    expect(addPathCall(0)).toMatchObject({ name: 'first', fills: black });
+    // Only the inheriting child is touched, the rest keep their own fills.
+    expect(addPathCall(1)).toMatchObject({ name: 'last', fills: white });
+  });
+
+  it.each<BoolOperations>(['union', 'intersection', 'exclude'])(
+    'propagates the fills to the last child of a %s',
+    boolType => {
+      createBool(context, bool(boolType, [path('first', white), path('last')]));
+
+      expect(addPathCall(0)).toMatchObject({ name: 'first', fills: white });
+      expect(addPathCall(1)).toMatchObject({ name: 'last', fills: black });
+    }
+  );
+
+  it('propagates the strokes and the fill style as well', () => {
+    colors.set('style-id', { fills: white });
+
+    createBool(
+      context,
+      bool('difference', [path('first')], { fills: [], fillStyleId: 'style-id', strokes })
+    );
+
+    expect(addPathCall(0)).toMatchObject({ fills: white, fillStyleId: 'style-id', strokes });
+  });
+
+  it('skips boards, which cannot take part in a boolean operation', () => {
+    createBool(context, bool('union', [path('first'), board('board')]));
+
+    expect(addBoard.mock.calls[0][0]).toMatchObject({ name: 'board', fills: white });
+    expect(addPathCall(0)).toMatchObject({ name: 'first', fills: black });
+  });
+
+  it('keeps its own fills when there is no child to inherit them', () => {
+    createBool(context, bool('union', []));
+
+    expect(addGroup.mock.calls[0][0]).toMatchObject({ name: 'Bool', fills: black });
+    expect(addPath).not.toHaveBeenCalled();
+  });
+});

--- a/ui-src/parser/creators/createBool.ts
+++ b/ui-src/parser/creators/createBool.ts
@@ -1,12 +1,24 @@
 import type { PenpotContext } from '@ui/lib/types/penpotContext';
-import type { BoolShape } from '@ui/lib/types/shapes/boolShape';
+import type { BoolOperations, BoolShape } from '@ui/lib/types/shapes/boolShape';
+import { BOOL_DIFFERENCE } from '@ui/lib/types/shapes/boolShape';
 import { createItems } from '@ui/parser/creators';
 import { symbolFills, symbolStrokes, symbolTouched } from '@ui/parser/creators/symbols';
+import type { PenpotNode } from '@ui/types';
+
+// Boards cannot take part in a boolean operation, so Penpot never inherits the
+// appearance from them, no matter where they sit among the children.
+const BOARD_TYPES = ['frame', 'component', 'instance'];
 
 export const createBool = (
   context: PenpotContext,
   { type: _type, children = [], boolType, ...shape }: BoolShape
 ): void => {
+  // Penpot builds the bool shape out of one of its children and discards the fills
+  // and strokes set on the bool itself. In Figma it works the other way around: the
+  // boolean operation node paints the whole result and its children are not rendered
+  // on their own. Propagating them keeps the Figma appearance.
+  propagateAppearanceToInheritingChild(shape, children, boolType);
+
   shape.fills = symbolFills(context, shape.fillStyleId, shape.fills);
   shape.strokes = symbolStrokes(context, shape.strokes);
   shape.touched = symbolTouched(
@@ -34,4 +46,42 @@ export const createBool = (
     // The shape will still be created, but it will be a normal group.
     console.warn('Could not add boolean group', shape.name, error);
   }
+};
+
+/**
+ * This overwrites the fills the inheriting child brought along, which is a deliberate
+ * trade-off: `addBool` derives the appearance of the bool from that child and offers
+ * no way to set it afterwards, so either the bool or that one child ends up with the
+ * wrong paints. The bool wins, because it is the one that paints the result — the
+ * fills of a child are dormant in Penpot and in Figma alike, and only ever show up
+ * once the boolean operation is dissolved.
+ */
+const propagateAppearanceToInheritingChild = (
+  shape: Omit<BoolShape, 'type' | 'children' | 'boolType'>,
+  children: PenpotNode[],
+  boolType: BoolOperations
+): void => {
+  const child = inheritingChild(children, boolType);
+
+  if (!child) return;
+
+  child.fills = shape.fills;
+  child.fillStyleId = shape.fillStyleId;
+  child.strokes = shape.strokes;
+};
+
+/**
+ * A difference keeps the shape it subtracts from as its base, so Penpot inherits the
+ * appearance from the first child. Every other operation folds the children together
+ * and ends up with the appearance of the last one.
+ */
+const inheritingChild = (
+  children: PenpotNode[],
+  boolType: BoolOperations
+): PenpotNode | undefined => {
+  const candidates = children.filter(child => !BOARD_TYPES.includes(child.type ?? ''));
+
+  return boolType === 'difference' || boolType === BOOL_DIFFERENCE
+    ? candidates[0]
+    : candidates[candidates.length - 1];
 };


### PR DESCRIPTION
## Problem

A boolean operation exported from Figma loses its paints in Penpot. In Figma the boolean node itself carries the fill and its children are usually unpainted, so the imported shape ends up with an empty `FILL` panel and renders as nothing.

Reported for a `Subtract` filled `#000000`, reproduced with a minimal `Union`.

## Cause

Not in the transformers — `transformBooleanNode` emits the fill correctly. It is lost
in `createBool`, which builds the shape as a group and then converts it via
`context.addBool()`.

`addBool` derives `:fills` and `:strokes` from **one** of the children and discards
whatever was set on the bool itself. Which child it picks depends on the operation:

| Bool type | inherits from |
| --- | --- |
| `difference` | first non-board child |
| `union` | last non-board child |
| `intersection` | last non-board child |
| `exclude` | last non-board child |

Boards (`frame`, `component`, `instance`) are skipped wherever they sit, since they
cannot take part in a boolean operation. Measured against `@penpot/library` 1.2.0-RC2
across all four operations with 2–4 children and boards at either end, and confirmed
in the bundled implementation.

Figma: 
<img width="1647" height="972" alt="grafik" src="https://github.com/user-attachments/assets/fc15eff7-1748-4d8d-baef-372dc6d82a86" />

Penpot:
<img width="1553" height="1054" alt="grafik" src="https://github.com/user-attachments/assets/753cc3a5-546f-4a42-a593-cb59dc6f81ac" />
