### PR TITLE
Background Blur

### DIFF
--- a/.changeset/export-background-blur.md
+++ b/.changeset/export-background-blur.md
@@ -1,0 +1,8 @@
+---
+'penpot-exporter': minor
+---
+
+Add an opt-in "Background blur" export option. Figma's `BACKGROUND_BLUR` effect was silently
+dropped before; with the checkbox enabled it is exported as Penpot's `background-blur` shape
+attribute. The effect is only painted by Penpot's WebGL renderer (2.17 or newer with "WebGL
+rendering (beta)" enabled), which is why it stays off by default.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Things that are currently included in the import are:
 - **Texts** (you can upload your own fonts too)
 - **All basic shapes properties** (fills, visibility, strokes, corner radius, shadows, rotations,
   effects, etc...)
+- **Background blur** (opt-in, see Limitations)
 - **Components, Components sets and Component instances**
 - **Auto Layouts**
 - **Color and Typography libraries**
@@ -161,6 +162,17 @@ Another obvious limitations are the features that are in Figma but not in Penpot
 in both tools so they can not be easily converted, consequently, some features may not look exactly
 the same. Additionally, **prototyping settings are currently not supported** in the export/import
 process of files.
+
+Two of those differences are worth calling out:
+
+- **Background blur** is only painted by Penpot's WebGL renderer, so it is exported behind an opt-in
+  checkbox and is off by default. Turn it on if your Penpot instance is 2.17 or newer and you have
+  "WebGL rendering (beta)" enabled; the classic renderer ignores the effect.
+- **Boolean groups containing text** arrive complete — the group and its text layers are all there —
+  but they render as a rectangle at first. The path of a boolean is precomputed when the file is
+  written, and text is measured by its bounding box at that point; Penpot stores that path and does
+  not recompute it when opening the file. Switching the boolean operation once in Penpot recomputes
+  it, and with "WebGL rendering (beta)" enabled the letter shapes then appear.
 
 ## Contributing
 

--- a/plugin-src/code.ts
+++ b/plugin-src/code.ts
@@ -3,7 +3,7 @@ import { getUserData } from '@plugin/getUserData';
 import { handleExportMessage, handleRetryMessage, postPluginError } from '@plugin/handleMessage';
 import { isFigJamEditor, isSlidesEditor } from '@plugin/utils';
 
-import type { ExportScope, ExternalLibrary } from '@ui/types';
+import type { ExportOptions, ExportScope, ExternalLibrary } from '@ui/types';
 
 const BASE_HEIGHT = 500;
 const BASE_WIDTH = 560;
@@ -14,6 +14,7 @@ type ExportMessage = {
     scope: ExportScope;
     libraries: ExternalLibrary[];
     pageIds?: string[];
+    options?: ExportOptions;
   };
 };
 
@@ -71,8 +72,9 @@ const onMessage: MessageEventHandler = message => {
       const scope = exportMessage.data?.scope ?? 'all';
       const libraries = exportMessage.data?.libraries ?? [];
       const pageIds = exportMessage.data?.pageIds ?? [];
+      const options = exportMessage.data?.options ?? { backgroundBlur: false };
 
-      handleExportMessage(scope, libraries, pageIds);
+      handleExportMessage(scope, libraries, pageIds, options);
     }
 
     if (message.type === 'cancel') {

--- a/plugin-src/handleMessage.ts
+++ b/plugin-src/handleMessage.ts
@@ -25,12 +25,19 @@ import {
   isFigJamEditor,
   isSlidesEditor,
   reportProgress,
-  resetProgress
+  resetProgress,
+  setExportOptions
 } from '@plugin/utils';
 import { ExpectedUserError } from '@plugin/utils/expectedUserError';
 import { isFigmaPlatformError } from '@plugin/utils/figmaPlatformError';
 
-import type { ErrorPayload, ExportScope, ExternalLibrary, PenpotDocument } from '@ui/types';
+import type {
+  ErrorPayload,
+  ExportOptions,
+  ExportScope,
+  ExternalLibrary,
+  PenpotDocument
+} from '@ui/types';
 
 const initializeExternalLibraries = (libraries: ExternalLibrary[]): void => {
   for (const library of libraries) {
@@ -68,12 +75,14 @@ export const postPluginError = (error: unknown): void => {
 export const handleExportMessage = async (
   scope: ExportScope,
   libraries: ExternalLibrary[],
-  pageIds: string[] = []
+  pageIds: string[] = [],
+  options: ExportOptions = { backgroundBlur: false }
 ): Promise<void> => {
   try {
     // Clear all state maps and caches to prevent memory accumulation
     clearAllState();
     resetProgress();
+    setExportOptions(options);
 
     initializeExternalLibraries(libraries);
     const document = await buildDocument(scope, pageIds);

--- a/plugin-src/transformers/partials/transformEffects.ts
+++ b/plugin-src/transformers/partials/transformEffects.ts
@@ -1,10 +1,20 @@
-import { translateBlurEffects, translateShadowEffects } from '@plugin/translators';
+import {
+  translateBackgroundBlurEffects,
+  translateBlurEffects,
+  translateShadowEffects
+} from '@plugin/translators';
+import { exportsBackgroundBlur } from '@plugin/utils';
 
 import type { ShapeAttributes } from '@ui/lib/types/shapes/shape';
 
-export const transformEffects = (node: BlendMixin): Pick<ShapeAttributes, 'shadow' | 'blur'> => {
+export const transformEffects = (
+  node: BlendMixin
+): Pick<ShapeAttributes, 'shadow' | 'blur' | 'backgroundBlur'> => {
   return {
     shadow: translateShadowEffects(node.effects),
-    blur: translateBlurEffects(node.effects)
+    blur: translateBlurEffects(node.effects),
+    backgroundBlur: exportsBackgroundBlur()
+      ? translateBackgroundBlurEffects(node.effects)
+      : undefined
   };
 };

--- a/plugin-src/translators/index.ts
+++ b/plugin-src/translators/index.ts
@@ -1,4 +1,5 @@
 export * from './translateAppliedTokens';
+export * from './translateBackgroundBlurEffects';
 export * from './translateBlendMode';
 export * from './translateBlurEffects';
 export * from './translateBoolType';

--- a/plugin-src/translators/translateBackgroundBlurEffects.ts
+++ b/plugin-src/translators/translateBackgroundBlurEffects.ts
@@ -1,0 +1,24 @@
+import { generateUuid } from '@plugin/utils';
+
+import type { BackgroundBlur } from '@ui/lib/types/utils/backgroundBlur';
+
+export const translateBackgroundBlurEffects = (
+  effects: readonly Effect[]
+): BackgroundBlur | undefined => {
+  // Penpot only stores a single radius, so a progressive background blur is
+  // flattened to its end radius, the same way layer blurs are handled.
+  const blur = effects.find(effect => effect.type === 'BACKGROUND_BLUR') as
+    | BlurEffectBase
+    | undefined;
+
+  if (!blur) {
+    return;
+  }
+
+  return {
+    id: generateUuid(),
+    type: 'background-blur',
+    value: blur.radius,
+    hidden: !blur.visible
+  };
+};

--- a/plugin-src/utils/exportOptions.ts
+++ b/plugin-src/utils/exportOptions.ts
@@ -1,0 +1,17 @@
+import type { ExportOptions } from '@ui/types';
+
+const DEFAULT_EXPORT_OPTIONS: ExportOptions = {
+  backgroundBlur: false
+};
+
+let exportOptions: ExportOptions = DEFAULT_EXPORT_OPTIONS;
+
+// Set once per export, before the document is built. It is authoritative for
+// the whole run, so there is nothing to reset in `clearAllState()`.
+export const setExportOptions = (options: ExportOptions): void => {
+  exportOptions = options;
+};
+
+// Background blur is only painted by Penpot's WebGL renderer, so exporting it
+// is opt-in. Expose it as a capability so partials gate on a behaviour.
+export const exportsBackgroundBlur = (): boolean => exportOptions.backgroundBlur;

--- a/plugin-src/utils/index.ts
+++ b/plugin-src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './calculateLinearGradient';
 export * from './calculateRadialGradient';
 export * from './clamp';
 export * from './editorType';
+export * from './exportOptions';
 export * from './finiteOrUndefined';
 export * from './generateUuid';
 export * from './matrixInvert';

--- a/tests/plugin-src/handleMessage.test.ts
+++ b/tests/plugin-src/handleMessage.test.ts
@@ -142,6 +142,24 @@ describe('handleExportMessage', () => {
     expect(mockTransformDocumentNode).toHaveBeenCalledWith(expect.anything(), 'all', []);
   });
 
+  it('applies the export options for the run', async () => {
+    mockTransformDocumentNode.mockResolvedValue({ name: 'doc' });
+
+    await handleExportMessage('all', [], [], { backgroundBlur: true });
+
+    const { exportsBackgroundBlur } = await import('@plugin/utils');
+    expect(exportsBackgroundBlur()).toBe(true);
+  });
+
+  it('defaults the export options to background blur off', async () => {
+    mockTransformDocumentNode.mockResolvedValue({ name: 'doc' });
+
+    await handleExportMessage('all', []);
+
+    const { exportsBackgroundBlur } = await import('@plugin/utils');
+    expect(exportsBackgroundBlur()).toBe(false);
+  });
+
   it('routes to slides transformer when editor is slides', async () => {
     mockIsSlidesEditor.mockReturnValue(true);
     mockTransformSlidesDocumentNode.mockResolvedValue({ name: 'slides-doc' });

--- a/tests/plugin-src/transformers/partials/transformEffects.test.ts
+++ b/tests/plugin-src/transformers/partials/transformEffects.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { transformEffects } from '@plugin/transformers/partials';
+import { setExportOptions } from '@plugin/utils';
+
+const node = {
+  effects: [
+    { type: 'LAYER_BLUR', blurType: 'NORMAL', radius: 4, visible: true },
+    { type: 'BACKGROUND_BLUR', blurType: 'NORMAL', radius: 12, visible: true }
+  ]
+} as unknown as BlendMixin;
+
+describe('transformEffects', () => {
+  beforeEach(() => {
+    setExportOptions({ backgroundBlur: false });
+  });
+
+  it('drops the background blur when the option is off', () => {
+    const { blur, backgroundBlur } = transformEffects(node);
+
+    expect(blur).toMatchObject({ type: 'layer-blur', value: 4 });
+    expect(backgroundBlur).toBeUndefined();
+  });
+
+  it('keeps the background blur when the option is on', () => {
+    setExportOptions({ backgroundBlur: true });
+
+    const { blur, backgroundBlur } = transformEffects(node);
+
+    expect(blur).toMatchObject({ type: 'layer-blur', value: 4 });
+    expect(backgroundBlur).toMatchObject({ type: 'background-blur', value: 12 });
+  });
+});

--- a/tests/plugin-src/translators/translateBackgroundBlurEffects.test.ts
+++ b/tests/plugin-src/translators/translateBackgroundBlurEffects.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { translateBackgroundBlurEffects } from '@plugin/translators';
+
+const backgroundBlur = (overrides: Partial<Effect> = {}): Effect =>
+  ({
+    type: 'BACKGROUND_BLUR',
+    blurType: 'NORMAL',
+    radius: 12,
+    visible: true,
+    ...overrides
+  }) as Effect;
+
+const layerBlur = (): Effect =>
+  ({ type: 'LAYER_BLUR', blurType: 'NORMAL', radius: 4, visible: true }) as Effect;
+
+describe('translateBackgroundBlurEffects', () => {
+  it('translates a background blur into a Penpot background-blur', () => {
+    const blur = translateBackgroundBlurEffects([backgroundBlur()]);
+
+    expect(blur).toMatchObject({
+      type: 'background-blur',
+      value: 12,
+      hidden: false
+    });
+    expect(blur?.id).toEqual(expect.any(String));
+  });
+
+  it('marks an invisible background blur as hidden', () => {
+    expect(translateBackgroundBlurEffects([backgroundBlur({ visible: false })])).toMatchObject({
+      hidden: true
+    });
+  });
+
+  it('flattens a progressive background blur to its end radius', () => {
+    const blur = translateBackgroundBlurEffects([
+      {
+        type: 'BACKGROUND_BLUR',
+        blurType: 'PROGRESSIVE',
+        radius: 20,
+        startRadius: 0,
+        startOffset: { x: 0, y: 0 },
+        endOffset: { x: 0, y: 1 },
+        visible: true
+      } as Effect
+    ]);
+
+    expect(blur).toMatchObject({ type: 'background-blur', value: 20 });
+  });
+
+  it('returns undefined when there is no background blur', () => {
+    expect(translateBackgroundBlurEffects([])).toBeUndefined();
+    expect(translateBackgroundBlurEffects([layerBlur()])).toBeUndefined();
+  });
+
+  it('picks the background blur when a layer blur is also present', () => {
+    expect(translateBackgroundBlurEffects([layerBlur(), backgroundBlur()])).toMatchObject({
+      type: 'background-blur',
+      value: 12
+    });
+  });
+});

--- a/ui-src/components/DesignExportControls.module.css
+++ b/ui-src/components/DesignExportControls.module.css
@@ -1,0 +1,15 @@
+/*
+ * The Checkbox of @create-figma-plugin lines its label slot up with the box
+ * using a `padding-top`, which only centres the text under the untouched 16px
+ * `line-height` of the library base styles; our reset.css sets
+ * `line-height: 1.5`, which drops the text below the middle of the box.
+ * Centring the row is independent of the line height.
+ * PageSelector.module.css carries the same correction for the page list.
+ */
+.option label {
+  align-items: center;
+}
+
+.option label > div:last-of-type {
+  padding-top: 0;
+}

--- a/ui-src/components/DesignExportControls.tsx
+++ b/ui-src/components/DesignExportControls.tsx
@@ -1,4 +1,9 @@
-import { Muted, SegmentedControl, type SegmentedControlOption } from '@create-figma-plugin/ui';
+import {
+  Checkbox,
+  Muted,
+  SegmentedControl,
+  type SegmentedControlOption
+} from '@create-figma-plugin/ui';
 import type { JSX, TargetedEvent } from 'preact';
 import { useEffect } from 'preact/hooks';
 import { useFormContext } from 'react-hook-form';
@@ -9,6 +14,8 @@ import { Stack } from '@ui/components/Stack';
 import { type FormValues, useFigmaContext } from '@ui/context';
 import type { ExportScope } from '@ui/types';
 
+import styles from './DesignExportControls.module.css';
+
 const scopeOptions: SegmentedControlOption[] = [
   { value: 'all', children: 'All pages' },
   { value: 'current', children: 'Current page' },
@@ -16,7 +23,13 @@ const scopeOptions: SegmentedControlOption[] = [
 ];
 
 export const DesignExportControls = (): JSX.Element => {
-  const { exportScope, exportLibraries, setExportScope } = useFigmaContext();
+  const {
+    exportScope,
+    exportLibraries,
+    exportBackgroundBlur,
+    setExportScope,
+    setExportBackgroundBlur
+  } = useFigmaContext();
   const { reset } = useFormContext<FormValues>();
 
   useEffect(() => {
@@ -47,6 +60,19 @@ export const DesignExportControls = (): JSX.Element => {
         </Muted>
 
         {exportScope === 'selection' && <PageSelector />}
+      </Stack>
+
+      <Stack space="xsmall">
+        <strong style={{ fontSize: 13 }}>Effects</strong>
+        <div className={styles.option}>
+          <Checkbox value={exportBackgroundBlur} onValueChange={setExportBackgroundBlur}>
+            <span>Background blur</span>
+          </Checkbox>
+        </div>
+        <Muted>
+          Penpot only paints background blur with WebGL rendering (beta) enabled, in version 2.17 or
+          newer. The classic renderer ignores it.
+        </Muted>
       </Stack>
 
       <ExternalLibrariesFieldSet />

--- a/ui-src/context/useFigma.ts
+++ b/ui-src/context/useFigma.ts
@@ -9,6 +9,7 @@ import type {
   DocumentPage,
   ErrorOrigin,
   ErrorPayload,
+  ExportOptions,
   ExportScope,
   ExternalLibrary,
   Steps
@@ -46,10 +47,12 @@ export type UseFigmaHook = {
   exportedBlob: { blob: Blob; filename: string } | null;
   exportTime: number | null;
   exportScope: ExportScope;
+  exportBackgroundBlur: boolean;
   exportLibraries: string[];
   documentPages: DocumentPage[];
   selectedPageIds: string[];
   setExportScope: (scope: ExportScope) => void;
+  setExportBackgroundBlur: (enabled: boolean) => void;
   setSelectedPageIds: (pageIds: string[]) => void;
   retry: () => void;
   cancel: () => void;
@@ -67,6 +70,7 @@ export const useFigma = (): UseFigmaHook => {
   const [exportedBlob, setExportedBlob] = useState<{ blob: Blob; filename: string } | null>(null);
   const [exportTime, setExportTime] = useState<number | null>(null);
   const [exportScope, setExportScope] = useState<ExportScope>('all');
+  const [exportBackgroundBlur, setExportBackgroundBlur] = useState<boolean>(false);
   const [exportLibraries, setExportLibraries] = useState<string[]>([]);
   const [documentPages, setDocumentPages] = useState<DocumentPage[]>([]);
   const [selectedPageIds, setSelectedPageIds] = useState<string[]>([]);
@@ -168,6 +172,7 @@ export const useFigma = (): UseFigmaHook => {
         setExportedBlob(null);
         setExportTime(null);
         setExportScope('all');
+        setExportBackgroundBlur(false);
         setSelectedPageIds(defaultPageIdsRef.current);
         setStep('processing');
         setCurrentItem('');
@@ -339,8 +344,11 @@ export const useFigma = (): UseFigmaHook => {
 
     track('File Export Started', {
       'scope': exportScope,
-      'Selected Pages': exportScope === 'selection' ? pageIds.length : undefined
+      'Selected Pages': exportScope === 'selection' ? pageIds.length : undefined,
+      'Background Blur': exportBackgroundBlur
     });
+
+    const options: ExportOptions = { backgroundBlur: exportBackgroundBlur };
 
     const libraries = data.externalLibraries
       .map(lib => ({
@@ -349,7 +357,12 @@ export const useFigma = (): UseFigmaHook => {
       }))
       .filter((lib): lib is ExternalLibrary => lib.uuid !== undefined);
 
-    postMessage('export', { scope: exportScope, libraries, pageIds });
+    postMessage('export', {
+      scope: exportScope,
+      libraries,
+      pageIds,
+      options
+    });
   };
 
   useEffect(() => {
@@ -395,10 +408,12 @@ export const useFigma = (): UseFigmaHook => {
     exportedBlob,
     exportTime,
     exportScope,
+    exportBackgroundBlur,
     exportLibraries,
     documentPages,
     selectedPageIds,
     setExportScope,
+    setExportBackgroundBlur,
     setSelectedPageIds,
     retry,
     cancel,

--- a/ui-src/lib/types/shapes/shape.ts
+++ b/ui-src/lib/types/shapes/shape.ts
@@ -1,4 +1,5 @@
 import type { TokenProperties } from '@ui/lib/types/shapes/tokens';
+import type { BackgroundBlur } from '@ui/lib/types/utils/backgroundBlur';
 import type { BlendMode } from '@ui/lib/types/utils/blendModes';
 import type { Blur } from '@ui/lib/types/utils/blur';
 import type { Export } from '@ui/lib/types/utils/export';
@@ -70,6 +71,7 @@ export type ShapeAttributes = {
   interactions?: Interaction[];
   shadow?: Shadow[];
   blur?: Blur;
+  backgroundBlur?: BackgroundBlur;
   growType?: GrowType;
   appliedTokens?: { [key in TokenProperties]?: string };
 

--- a/ui-src/lib/types/utils/backgroundBlur.ts
+++ b/ui-src/lib/types/utils/backgroundBlur.ts
@@ -1,0 +1,11 @@
+import type { Uuid } from './uuid';
+
+// Penpot models background blur as its own shape attribute (not as a `Blur`
+// variant) and requires every field, unlike the layer blur where `id` is
+// optional. Only the WebGL renderer paints it; the SVG renderer ignores it.
+export type BackgroundBlur = {
+  id: Uuid;
+  type: 'background-blur';
+  value: number;
+  hidden: boolean;
+};

--- a/ui-src/types/progressMessages.ts
+++ b/ui-src/types/progressMessages.ts
@@ -4,6 +4,11 @@ import type { ErrorPayload } from './errorPayload';
 
 export type ExportScope = 'all' | 'current' | 'selection';
 
+// Opt-in export features that only Penpot's WebGL renderer understands.
+export type ExportOptions = {
+  backgroundBlur: boolean;
+};
+
 export type DocumentPage = {
   id: string;
   name: string;


### PR DESCRIPTION
Figma's `BACKGROUND_BLUR` effect was silently dropped on export — the translator only matched `LAYER_BLUR`. This adds it behind an opt-in checkbox, exported as Penpot's `background-blur` shape attribute.

- New "Background blur" checkbox in the export form, **off by default**
- `translateBackgroundBlurEffects` mirrors the existing layer-blur translator; a progressive background blur is flattened to its end radius, same as we already do for layer blurs

**Why opt-in:** Penpot only paints background blur with the WebGL renderer. The classic SVG renderer ignores the attribute. Older Penpot instances don't decode it either, so it just sits inert; defaulting to off keeps existing exports byte-identical.

**No library bump needed.** `@penpot/library@1.2.0-RC2` predates the feature and its schema:shape-generic-attrs` doesn't list `:background-blur`, but it passes the attribute through unchanged: the malli map is open, `decode-shape` is a decoder rather than a check-fn, and `setup-shape` merges without a whitelist. Verified end to end by exporting a `.penpot` and reading the shape JSON back — `frame`, `rect` and `text` all carry `{"type":"background-blur","value":…,"hidden":…}`, and with the checkbox off the key is absent.


<img width="1567" height="1004" alt="grafik" src="https://github.com/user-attachments/assets/95354fa3-14b4-4131-916a-e4537b8eb266" />


[union_test_file.penpot.zip](https://github.com/user-attachments/files/32129595/union_test_file.penpot.zip)
